### PR TITLE
Added another option for multi select filter

### DIFF
--- a/jquery.dataTables.yadcf.js
+++ b/jquery.dataTables.yadcf.js
@@ -740,6 +740,8 @@ var yadcf = (function ($) {
 					case "id":
 						val = val.id;
 						break;
+                                        default:
+                                                val = $(val).data(html_data_type);
 					}
 				}
 
@@ -1359,15 +1361,21 @@ var yadcf = (function ($) {
 									case "id":
 										col_inner_data = col_inner_elements[k].id;
 										break;
-									}
-								}
-							} else {
-								col_inner_data = col_inner_elements.selector;
-							}
-							if (!(col_filter_array.hasOwnProperty(col_inner_data))) {
-								col_filter_array[col_inner_data] = col_inner_data;
-								options.push(col_inner_data);
-							}
+                                                                        default:
+                                                                                col_inner_data = $(col_inner_elements[k]).data(html_data_type);
+                                                                        }
+                                                                        if (col_inner_data && !(col_filter_array.hasOwnProperty(col_inner_data))) {
+                                                                                col_filter_array[col_inner_data] = col_inner_data;
+                                                                                options.push(col_inner_data);
+                                                                        }
+                                                                }
+                                                        } else {
+                                                                col_inner_data = col_inner_elements.selector;
+                                                                if (!(col_filter_array.hasOwnProperty(col_inner_data))) {
+                                                                        col_filter_array[col_inner_data] = col_inner_data;
+                                                                        options.push(col_inner_data);
+                                                                }
+                                                        }
 						} else if (column_data_type === "text") {
 							if (text_data_delimiter !== undefined) {
 								if (column_number_data === undefined) {


### PR DESCRIPTION
I found the plugin useful but my table each cell had multiple spans and I wanted an attribute from each span to be selectable in a multi select. My changes are very simple but let each child element contribute a value to the multi select. Plus, you can specify a data attribute like 'data-foo' in the html element and extract it with the name 'foo' in the column config.

Thanks for a great plugin