### PR TITLE
Honor sort_as with multi_select_custom_func

### DIFF
--- a/jquery.dataTables.yadcf.js
+++ b/jquery.dataTables.yadcf.js
@@ -1393,7 +1393,7 @@ var yadcf = (function ($) {
 	}
 
 	function sortColumnData(column_data, columnObj) {
-		if (columnObj.filter_type === "select" || columnObj.filter_type === "auto_complete" || columnObj.filter_type === "multi_select" || columnObj.filter_type === "custom_func") {
+		if (columnObj.filter_type === "select" || columnObj.filter_type === "auto_complete" || columnObj.filter_type === "multi_select" || columnObj.filter_type === 'multi_select_custom_func' || columnObj.filter_type === "custom_func") {
 			if (columnObj.sort_as === "alpha") {
 				if (columnObj.sort_order === "asc") {
 					column_data.sort();


### PR DESCRIPTION
This could be undesirable to anyone depending on it working as it did, but it doesn't seem like it's documented to ignore sorting when using multi_select_custom_func.

There could be other places that need this, but this change seemed to work for my usecase at least.