### PR TITLE
added a step option for range_number_slider filter type

### DIFF
--- a/jquery.dataTables.yadcf.js
+++ b/jquery.dataTables.yadcf.js
@@ -1692,8 +1692,10 @@ var yadcf = (function ($) {
 					rangeNumberSldierDrawTips(ui.values[0], ui.values[1], min_tip_id, max_tip_id, table_selector_jq_friendly, column_number);
 				};
 			}
+			var step_option = columnObj["filter_plugin_options"].step ? columnObj["filter_plugin_options"].step : '';
 			sliderObj = {
 				range: true,
+				step:step_option,
 				min: min_val,
 				max: max_val,
 				values: [min_state_val, max_state_val],


### PR DESCRIPTION
I was using  filter_type : 'range_number_slider' for which i needed a step option in my range_number_slider filter type

added this in my .js file
for eg:
yadcf.init(oTable, [{
               column_number : 3,
               filter_type : 'range_number_slider',
               filter_plugin_options: {step:0.1}
 }


Handled this in the library by accessing the columnObj["filter_plugin_options"].step and then adding the step as a property in sliderObj

var step_option = columnObj["filter_plugin_options"].step ? columnObj["filter_plugin_options"].step : '';
			sliderObj = {
				range: true,
				step:step_option,
				min: min_val,
				max: max_val,
				values: [min_state_val, max_state_val],
				create: function (event, ui) {
			           rangeNumberSldierDrawTips(min_state_val, max_state_val, 
                                   min_tip_id,max_tip_id,   
                                   table_selector_jq_friendly, column_number);
			        },
				slide: slideFunc,
				change: changeFunc
			};

