### PR TITLE
Added license information to bower.json so that it can be deployed to webjars.org repository

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,5 +21,6 @@
 		"filter",
 		"column",
 		"plugin"
-	]
+	],
+	"license": "MIT"
 }


### PR DESCRIPTION
I need to use your library in a proyect using webjars and when I tried to add it to http://www.webjars.org/bower it fails because bower.json doesn't contain the license information: "The bower.json file should specify the license. This will have to be fixed upstream."

Thanks