### PR TITLE
jQuery 3+ compatablility: Set instance.selector

### DIFF
--- a/jquery.dataTables.yadcf.js
+++ b/jquery.dataTables.yadcf.js
@@ -3605,6 +3605,13 @@ var yadcf = (function ($) {
 			tmpParams,
 			tableSelector = '#' + oTable.table().node().id;
 
+	    /*
+        instance.selector will be undefined even though it is needed; set instance.selector to tableSelector.
+        */
+		if (typeof instance.selector === 'undefined' || instance.selector === null) {
+		    instance.selector = tableSelector;
+		}
+
 		if (params === undefined) {
 			params = {};
 		}


### PR DESCRIPTION
In jQuery 3+, within yadcf.init() the DataTables instance, referenced by the local instance variable, doesn't have a selector property. It is undefined.

Recreating the selector property and setting it to the local tableSelector variable allows yadcf to be jQuery 3+ compatable.

Tested with jQuery 3.1.0