### PR TITLE
Added support to AMD and CommonJS

### DIFF
--- a/jquery.dataTables.yadcf.js
+++ b/jquery.dataTables.yadcf.js
@@ -404,7 +404,16 @@
                                     filter_container_id: '' (required),
                 Note:               All the usual properties of yadcf should be supported in initMultipleColumns too!
 */
-var yadcf = (function ($) {
+(function (root, factory) {
+  if (typeof define === 'function' && define.amd) {
+    define(['jquery'], factory);
+  } else if (typeof module === 'object' && module.exports) {
+    module.exports = factory(require('jquery'));
+  } else {
+    root.yadcf = factory(root.jQuery);
+  }
+}(this, function($) {
+var yadcf = (function () {
 
     'use strict';
 
@@ -4363,4 +4372,9 @@ var yadcf = (function ($) {
         generateTableSelectorJQFriendly2: generateTableSelectorJQFriendly2
     };
 
-}(jQuery));
+}());
+    if (window) {
+        window.yadcf = yadcf;
+    }
+    return yadcf;
+}));


### PR DESCRIPTION
I'm using webpack and without this I'm not able to do 

    var table = $('#dtTable').DataTable(...);
    yadcf.init(table , [{column_number : 0}]);

because yadcf is not available.

I've followed [this guide](http://ifandelse.com/its-not-hard-making-your-library-support-amd-and-commonjs/).

Ps: I've not tested this in a simple browser environment but it should works.

**Update**: there is a problem, inline codes like `onclick="yadcf.stopPropagation(event);"` can't works without the global `yadcf` variable.