### PR TITLE
Resets minDate and maxDate from jquery-ui datepickers when clearing date range filter

### DIFF
--- a/jquery.dataTables.yadcf.js
+++ b/jquery.dataTables.yadcf.js
@@ -2836,7 +2836,8 @@ var yadcf = (function ($) {
             settingsDt,
             column_number_filter,
             currentFilterValues,
-            columnObj;
+            columnObj,
+            dateRange;
 
         settingsDt = getSettingsObjFromTable(oTable);
 
@@ -2850,6 +2851,13 @@ var yadcf = (function ($) {
         columnObj = getOptions(oTable.selector)[column_number];
 
         $(event.target).parent().find(".yadcf-filter-range").val("");
+        dateRange = $(event.target).parent().find(".yadcf-filter-range-date");
+        if (dateRange.length > 0) {
+            if (columnObj.datepicker_type === 'jquery-ui') {
+                $(dateRange[0]).datepicker('option', 'maxDate', null);
+                $(dateRange[1]).datepicker('option', 'minDate', null);
+            }
+        }
         if ($(event.target).parent().find(".yadcf-filter-range-number").length > 0) {
             $($(event.target).parent().find(".yadcf-filter-range")[0]).focus();
         }


### PR DESCRIPTION
When you clear a date range filter fields are reset, but minDate and maxDate in the (jquery-ui) datepickers are kept. If you try to select dates afterwards, the datepickers are limited by those min and max dates. I've added a reset for those options. It's limited to jquery-ui datepickers, I haven't tried with others.