### PR TITLE
update select filters dropdown with new data

### DIFF
--- a/src/jquery.dataTables.yadcf.js
+++ b/src/jquery.dataTables.yadcf.js
@@ -429,7 +429,16 @@
 * exFilterExternallyTriggered
                 Description:        Triggers all the available filters, should be used only when the externally_triggered option used
                 Arguments:          table_arg: (variable of the datatable)
-                Usage example:      yadcf.exResetAllFilters(table_arg);
+								Usage example:      yadcf.exResetAllFilters(table_arg);
+
+* exRefreshColumnFilterWithDataProp
+								Description:        Updates column filter with new data, when data property was used in initialization for this filter
+																		 e.g. select filter, when we used data property and we want to update it
+								Arguments:          table_arg: variable of the datatable
+																		col_num: number index of column filter
+																		updatedData: array of new data (use same data structure as was used in yadcf.init options)
+								Usage example:      yadcf.exRefreshColumnFilterWithDataProp(table_arg, 5, ['One', 'Two', 'Three']);
+
 *
 *
 *
@@ -5516,6 +5525,17 @@ if (!Object.entries) {
 			selector.find('.yadcf-null-wrapper :checkbox').prop('checked', false);
 		}
 
+		function exRefreshColumnFilterWithDataProp(table_arg, col_num, updatedData) {
+			if (table_arg.settings !== undefined) {
+				table_arg = table_arg.settings()[0].oInstance;
+			}
+			var columnsObj = getOptions(table_arg.selector);
+			var columnObj = columnsObj[col_num];
+			columnObj.data = updatedData;
+			var table_selector_jq_friendly = yadcf.generateTableSelectorJQFriendly2(table_arg);
+			refreshSelectPlugin(columnObj, $("#yadcf-filter-" + table_selector_jq_friendly + "-" + col_num));
+		}
+
 		return {
 			init: init,
 			doFilter: doFilter,
@@ -5547,7 +5567,8 @@ if (!Object.entries) {
 			exResetFilters: exResetFilters,
 			initSelectPluginCustomTriggers: initSelectPluginCustomTriggers,
 			preventDefaultForEnter: preventDefaultForEnter,
-			generateTableSelectorJQFriendly2: generateTableSelectorJQFriendly2
+			generateTableSelectorJQFriendly2: generateTableSelectorJQFriendly2,
+			exRefreshColumnFilterWithDataProp: exRefreshColumnFilterWithDataProp
 		};
 
 	}());


### PR DESCRIPTION
if we use data prop when we initialize yadcf select filters ( e.g. ajax loaded table data), and later we add new records dropdown is missing new records,  Added external function which updates select filter with new data.

jsfiddle: http://jsfiddle.net/rmahnwce/