### PR TITLE
Workaround for #614

### DIFF
--- a/src/jquery.dataTables.yadcf.js
+++ b/src/jquery.dataTables.yadcf.js
@@ -4453,7 +4453,7 @@ if (!Object.entries) {
 		}
 
 		function saveTextKeyUpState(oTable, table_selector_jq_friendly, column_number, regex_check_box, null_checked, exclude) {
-			if (oTable.fnSettings().oFeatures.bStateSave === true && oTable.fnSettings().oLoadedState.yadcfState) {
+			if (oTable.fnSettings().oFeatures.bStateSave === true && oTable.fnSettings().oLoadedState && oTable.fnSettings().oLoadedState.yadcfState) {
 				if (oTable.fnSettings().oLoadedState.yadcfState !== undefined && oTable.fnSettings().oLoadedState.yadcfState[table_selector_jq_friendly] !== undefined) {
 					oTable.fnSettings().oLoadedState.yadcfState[table_selector_jq_friendly][column_number] =
 						{


### PR DESCRIPTION
This is an obvious "fix" for my case of #614 and my app and the testcafe tests work.

I don't know why oLoadedState is null here, why the legacy api is apparently used and there are lots of other things I don't know.