### PR TITLE
Use proper jQuery objects instead of strings for better security

### DIFF
--- a/jquery.dataTables.yadcf.js
+++ b/jquery.dataTables.yadcf.js
@@ -485,7 +485,7 @@ if (!Object.entries) {
 				date: 'Select a date'
 			},
 			settingsMap = {};
-			
+
 		let closeBootstrapDatepicker = false;
 		let	closeBootstrapDatepickerRange = false;
 		let	closeSelect2 = false;
@@ -661,7 +661,7 @@ if (!Object.entries) {
 				}
 			}
 			options[selector_arg] = tmpOptions;
-			
+
 			check3rdPPluginsNeededClose();
 		}
 
@@ -672,7 +672,7 @@ if (!Object.entries) {
 						if (columnEntry[1].filter_type === 'range_date') {
 							closeBootstrapDatepickerRange = true;
 						} else {
-							closeBootstrapDatepicker = true;	
+							closeBootstrapDatepicker = true;
 						}
 					} else if (columnEntry[1].select_type === 'select2') {
 						closeSelect2 = true;
@@ -680,7 +680,7 @@ if (!Object.entries) {
 				});
 			});
 		}
-		
+
 		//taken and modified from DataTables 1.10.0-beta.2 source
 		function yadcfVersionCheck(version) {
 			var aThis = $.fn.dataTable.ext.sVersion.split('.'),
@@ -1127,7 +1127,7 @@ if (!Object.entries) {
 		}
 
 		function findMinInArray(array, columnObj) {
-			var narray = [], 
+			var narray = [],
 				i,
 				num,
 				min;
@@ -1157,7 +1157,7 @@ if (!Object.entries) {
 					min = -1 * Math.ceil(min * -1);
 				}
 			}
-			
+
 			return min;
 		}
 
@@ -1419,7 +1419,7 @@ if (!Object.entries) {
 							val = val['@' + columnObj.html5_data];
 						}
 					}
-					
+
 					//omit empty rows when filtering
 					if (val === '' && (min !== '' || max !== '')) {
 						return false;
@@ -1514,26 +1514,52 @@ if (!Object.entries) {
 			columnObj = getOptions(oTable.selector)[column_number];
 
 			//add a wrapper to hold both filter and reset button
-			$(filter_selector_string).append("<div onmousedown=\"yadcf.stopPropagation(event);\" onclick=\"yadcf.stopPropagation(event);\"  id=\"" + filter_wrapper_id + "\" class=\"yadcf-filter-wrapper " + columnObj.style_class + "\"></div>");
+			$(filter_selector_string).append($("<div>", {
+				onmousedown: "yadcf.stopPropagation(event);",
+				onclick: "yadcf.stopPropagation(event);",
+				id: filter_wrapper_id,
+				class: "yadcf-filter-wrapper " + columnObj.style_class
+			}));
 			filter_selector_string += " div.yadcf-filter-wrapper";
 			filter_selector_string_tmp = filter_selector_string;
 
-			$(filter_selector_string).append("<div id=\"yadcf-filter-wrapper-inner-" + table_selector_jq_friendly + "-" + column_number + "\" class=\"yadcf-filter-wrapper-inner" + " -" + table_selector_jq_friendly + "-" + column_number + "\"></div>");
+			$(filter_selector_string).append($("<div>", {
+				id: "yadcf-filter-wrapper-inner-" + table_selector_jq_friendly + "-" + column_number,
+				class: "yadcf-filter-wrapper-inner" + " -" + table_selector_jq_friendly + "-" + column_number
+			}));
 			filter_selector_string += " div.yadcf-filter-wrapper-inner";
 
-			filterActionStr = 'onkeyup="yadcf.rangeNumberKeyUP(\'' + table_selector_jq_friendly + '\',event);"';
+			filterActionStr = 'yadcf.rangeNumberKeyUP(\'' + table_selector_jq_friendly + '\',event);';
 			if (columnObj.externally_triggered === true) {
 				filterActionStr = '';
 			}
 
-			$(filter_selector_string).append("<input onkeydown=\"yadcf.preventDefaultForEnter(event);\" placeholder=\"" + filter_default_label[0] + "\" id=\"" + fromId + "\" class=\"yadcf-filter-range-number yadcf-filter-range\" " + filterActionStr + "></input>");
-			$(filter_selector_string).append("<span class=\"yadcf-filter-range-number-seperator\" >" +
-				"</span>");
-			$(filter_selector_string).append("<input onkeydown=\"yadcf.preventDefaultForEnter(event);\" placeholder=\"" + filter_default_label[1] + "\" id=\"" + toId + "\" class=\"yadcf-filter-range-number yadcf-filter-range\" " + filterActionStr + "></input>");
+			$(filter_selector_string).append($("<input>", {
+				onkeydown: "yadcf.preventDefaultForEnter(event);",
+				placeholder: filter_default_label[0],
+				id: fromId,
+				class: "yadcf-filter-range-number yadcf-filter-range",
+				onkeyup: filterActionStr
+			}));
+			$(filter_selector_string).append($("<span>", {
+				class: "yadcf-filter-range-number-seperator"
+			}));
+			$(filter_selector_string).append($("<input>", {
+				onkeydown: "yadcf.preventDefaultForEnter(event);",
+				placeholder: filter_default_label[1],
+				id: toId,
+				class: "yadcf-filter-range-number yadcf-filter-range",
+				onkeyup: filterActionStr
+			}));
 
 			if (filter_reset_button_text !== false) {
-				$(filter_selector_string_tmp).append("<button type=\"button\" onmousedown=\"yadcf.stopPropagation(event);\" " +
-					"onclick=\"yadcf.stopPropagation(event);yadcf.rangeClear('" + table_selector_jq_friendly + "',event," + column_number + "); return false;\" class=\"yadcf-filter-reset-button " + columnObj.reset_button_style_class + "\">" + filter_reset_button_text + "</button>");
+				$(filter_selector_string_tmp).append($("<button>", {
+					type: "button",
+					onmousedown: "yadcf.stopPropagation(event);",
+					onclick: "yadcf.stopPropagation(event);yadcf.rangeClear('" + table_selector_jq_friendly + "',event," + column_number + "); return false;",
+					class: "yadcf-filter-reset-button " + columnObj.reset_button_style_class,
+					text: filter_reset_button_text
+				}));
 			}
 
 			if (oTable.fnSettings().oFeatures.bStateSave === true && oTable.fnSettings().oLoadedState) {
@@ -1767,28 +1793,55 @@ if (!Object.entries) {
 				innerWrapperAdditionalClass = 'input-daterange';
 			}
 			//add a wrapper to hold both filter and reset button
-			$(filter_selector_string).append("<div onmousedown=\"yadcf.stopPropagation(event);\" onclick=\"yadcf.stopPropagation(event);\"  id=\"" + filter_wrapper_id + "\" class=\"yadcf-filter-wrapper " + columnObj.style_class + "\"></div>");
+			$(filter_selector_string).append($("<div>", {
+				onmousedown: "yadcf.stopPropagation(event);",
+				onclick: "yadcf.stopPropagation(event);",
+				id: filter_wrapper_id,
+				class: "yadcf-filter-wrapper" + columnObj.style_class
+			}));
 			filter_selector_string += " div.yadcf-filter-wrapper";
 			filter_selector_string_tmp = filter_selector_string;
 
-			$(filter_selector_string).append("<div id=\"yadcf-filter-wrapper-inner-" + table_selector_jq_friendly + "-" + column_number + "\" class=\"yadcf-filter-wrapper-inner " + innerWrapperAdditionalClass + "\"></div>");
+			$(filter_selector_string).append($("<div>", {
+				id: "yadcf-filter-wrapper-inner-" + table_selector_jq_friendly + "-" + column_number,
+				class: "yadcf-filter-wrapper-inner " + innerWrapperAdditionalClass
+			}));
 			filter_selector_string += " div.yadcf-filter-wrapper-inner";
 
-			filterActionStr = 'onkeyup="yadcf.rangeDateKeyUP(\'' + table_selector_jq_friendly + '\',\'' + date_format + '\',event);"';
+			filterActionStr = 'yadcf.rangeDateKeyUP(\'' + table_selector_jq_friendly + '\',\'' + date_format + '\',event);';
 			if (columnObj.externally_triggered === true) {
 				filterActionStr = '';
 			}
 
-			$(filter_selector_string).append("<input onkeydown=\"yadcf.preventDefaultForEnter(event);\" placeholder=\"" + filter_default_label[0] + "\" id=\"" + fromId + "\" class=\"yadcf-filter-range-date yadcf-filter-range yadcf-filter-range-start\" " + filterActionStr + "></input>");
-			$(filter_selector_string).append("<span class=\"yadcf-filter-range-date-seperator\" >" + "</span>");
-			$(filter_selector_string).append("<input onkeydown=\"yadcf.preventDefaultForEnter(event);\" placeholder=\"" + filter_default_label[1] + "\" id=\"" + toId + "\" class=\"yadcf-filter-range-date yadcf-filter-range yadcf-filter-range-end\" " + filterActionStr + "></input>");
+			$(filter_selector_string).append($("<input>", {
+				onkeydown: "yadcf.preventDefaultForEnter(event);",
+				placeholder: filter_default_label[0],
+				id: fromId,
+				class: "yadcf-filter-range-date yadcf-filter-range yadcf-filter-range-start",
+				onkeyup: filterActionStr,
+			}));
+			$(filter_selector_string).append($("<span>", {
+				class: "yadcf-filter-range-date-seperator",
+			}));
+			$(filter_selector_string).append($("<input>", {
+				onkeydown: "yadcf.preventDefaultForEnter(event);",
+				placeholder: filter_default_label[1],
+				id: toId,
+				class: "yadcf-filter-range-date yadcf-filter-range yadcf-filter-range-end",
+				onkeyup: filterActionStr,
+			}));
 
 			$fromInput = $("#" + fromId);
 			$toInput = $("#" + toId);
 
 			if (filter_reset_button_text !== false) {
-				$(filter_selector_string_tmp).append("<button type=\"button\" onmousedown=\"yadcf.stopPropagation(event);\" " +
-					"onclick=\"yadcf.stopPropagation(event);yadcf.rangeClear('" + table_selector_jq_friendly + "',event," + column_number + "); return false;\" class=\"yadcf-filter-reset-button " + columnObj.reset_button_style_class + "\">" + filter_reset_button_text + "</button>");
+				$(filter_selector_string_tmp).append($("<button>", {
+					type: "button",
+					onmousedown: "yadcf.stopPropagation(event);",
+					onclick: "yadcf.stopPropagation(event);yadcf.rangeClear('" + table_selector_jq_friendly + "',event," + column_number + "); return false;",
+					class: "yadcf-filter-reset-button " + columnObj.reset_button_style_class,
+					text: filter_reset_button_text
+				}));
 			}
 
 			if (columnObj.datepicker_type === 'jquery-ui') {
@@ -1875,20 +1928,37 @@ if (!Object.entries) {
 			columnObj = getOptions(oTable.selector)[column_number];
 
 			//add a wrapper to hold both filter and reset button
-			$(filter_selector_string).append("<div onmousedown=\"yadcf.stopPropagation(event);\" onclick=\"yadcf.stopPropagation(event);\" id=\"" + filter_wrapper_id + "\" class=\"yadcf-filter-wrapper\"></div>");
+			$(filter_selector_string).append($("<div>", {
+				onmousedown: "yadcf.stopPropagation(event);",
+				onclick: "yadcf.stopPropagation(event);",
+				id: filter_wrapper_id,
+				class: "yadcf-filter-wrapper"
+			}));
 			filter_selector_string += " div.yadcf-filter-wrapper";
 			filter_selector_string_tmp = filter_selector_string;
 
-			filterActionStr = 'onkeyup="yadcf.dateKeyUP(\'' + table_selector_jq_friendly + '\',\'' + date_format + '\',event);"';
+			filterActionStr = 'yadcf.dateKeyUP(\'' + table_selector_jq_friendly + '\',\'' + date_format + '\',event);';
 			if (columnObj.externally_triggered === true) {
 				filterActionStr = '';
 			}
 
-			$(filter_selector_string).append("<input onkeydown=\"yadcf.preventDefaultForEnter(event);\" placeholder=\"" + filter_default_label + "\" id=\"" + dateId + "\" class=\"yadcf-filter-date\" " + filterActionStr + "></input>");
+			$(filter_selector_string).append($("<input>", {
+				onkeydown: "yadcf.preventDefaultForEnter(event);",
+				placeholder: filter_default_label,
+				id: dateId,
+				class: "yadcf-filter-date",
+				onkeyup: filterActionStr,
+			}));
 
 			if (filter_reset_button_text !== false) {
-				$(filter_selector_string_tmp).append('<button type="button" id="' + dateId + '-reset" ' + 'onmousedown="yadcf.stopPropagation(event);" ' +
-					'onclick="yadcf.stopPropagation(event);yadcf.dateSelectSingle(\'' + table_selector_jq_friendly + '\',yadcf.eventTargetFixUp(event).target, \'clear\'); return false;" class="yadcf-filter-reset-button ' + columnObj.reset_button_style_class + '">' + filter_reset_button_text + '</button>');
+				$(filter_selector_string_tmp).append($("<button>", {
+					type: "button",
+					id: dateId + "-reset",
+					onmousedown: "yadcf.stopPropagation(event);",
+					onclick: "yadcf.stopPropagation(event);yadcf.dateSelectSingle('" + table_selector_jq_friendly + "',yadcf.eventTargetFixUp(event).target, 'clear'); return false;",
+					class: "yadcf-filter-reset-button " + columnObj.reset_button_style_class,
+					text: filter_reset_button_text
+				}));
 			}
 
 			if (columnObj.datepicker_type === 'jquery-ui') {
@@ -1954,8 +2024,16 @@ if (!Object.entries) {
 				min_tip_inner,
 				max_tip_inner;
 
-			min_tip_inner = "<div id=\"" + min_tip_id + "\" class=\"yadcf-filter-range-number-slider-min-tip-inner\">" + min_tip_val + "</div>";
-			max_tip_inner = "<div id=\"" + max_tip_id + "\" class=\"yadcf-filter-range-number-slider-max-tip-inner\">" + max_tip_val + "</div>";
+			min_tip_inner = $("<div>", {
+				id: min_tip_id,
+				class: "yadcf-filter-range-number-slider-min-tip-inner",
+				text: min_tip_val
+			});
+			max_tip_inner = $("<div>", {
+				id: max_tip_id,
+				class: "yadcf-filter-range-number-slider-max-tip-inner",
+				text: max_tip_val
+			});
 
 			if (first_handle.length === 1) {
 				first_handle = $(".yadcf-number-slider-filter-wrapper-inner.-" + table_selector_jq_friendly + "-" + column_number + " .ui-slider-handle:first");
@@ -2114,18 +2192,35 @@ if (!Object.entries) {
 			if (isFinite(min_val) && isFinite(max_val) && isFinite(min_state_val) && isFinite(max_state_val)) {
 
 				//add a wrapper to hold both filter and reset button
-				$(filter_selector_string).append("<div onmousedown=\"yadcf.stopPropagation(event);\" onclick=\"yadcf.stopPropagation(event);\"  id=\"" + filter_wrapper_id + "\" class=\"yadcf-filter-wrapper " + columnObj.style_class + "\"></div>");
+				$(filter_selector_string).append($("<div>", {
+					onmousedown: "yadcf.stopPropagation(event);",
+					onclick: "yadcf.stopPropagation(event);",
+					id: filter_wrapper_id,
+					class: "yadcf-filter-wrapper " + columnObj.style_class
+				}));
 				filter_selector_string += " div.yadcf-filter-wrapper";
 				filter_selector_string_tmp = filter_selector_string;
 
-				$(filter_selector_string).append("<div id=\"yadcf-filter-wrapper-inner-" + table_selector_jq_friendly + "-" + column_number + "\" class=\"yadcf-number-slider-filter-wrapper-inner" + " -" + table_selector_jq_friendly + "-" + column_number + "\"></div>");
+				$(filter_selector_string).append($("<div>", {
+					id: "yadcf-filter-wrapper-inner-" + table_selector_jq_friendly + "-" + column_number,
+					class: "yadcf-number-slider-filter-wrapper-inner" + " -" + table_selector_jq_friendly + "-" + column_number
+				}));
 				filter_selector_string += " div.yadcf-number-slider-filter-wrapper-inner";
 
-				$(filter_selector_string).append("<div id=\"" + sliderId + "\" class=\"yadcf-filter-range-number-slider\"></div>");
+				$(filter_selector_string).append($("<div>", {
+					id: sliderId,
+					class: "yadcf-filter-range-number-slider"
+				}));
 				filter_selector_string += " #" + sliderId;
 
-				$(filter_selector_string).append("<span class=\"yadcf-filter-range-number-slider-min-tip-hidden hide\">" + min_val + "</span>");
-				$(filter_selector_string).append("<span class=\"yadcf-filter-range-number-slider-max-tip-hidden hide\">" + max_val + "</span>");
+				$(filter_selector_string).append($("<span>", {
+					class: "yadcf-filter-range-number-slider-min-tip-hidden hide",
+					text: min_val
+				}));
+				$(filter_selector_string).append($("<span>", {
+					class: "yadcf-filter-range-number-slider-max-tip-hidden hide",
+					text: max_val
+				}));
 
 				if (columnObj.externally_triggered !== true) {
 					slideFunc = function (event, ui) {
@@ -2166,8 +2261,13 @@ if (!Object.entries) {
 				$("#" + sliderId).slider(sliderObj);
 
 				if (filter_reset_button_text !== false) {
-					$(filter_selector_string_tmp).append("<button type=\"button\" onmousedown=\"yadcf.stopPropagation(event);\" " +
-						"onclick=\"yadcf.stopPropagation(event);yadcf.rangeNumberSliderClear('" + table_selector_jq_friendly + "',event); return false;\" class=\"yadcf-filter-reset-button range-number-slider-reset-button " + columnObj.reset_button_style_class + "\">" + filter_reset_button_text + "</button>");
+					$(filter_selector_string_tmp).append($("<button>", {
+						type: "button",
+						onmousedown: "yadcf.stopPropagation(event);",
+						onclick: "yadcf.stopPropagation(event);yadcf.rangeNumberSliderClear('" + table_selector_jq_friendly + "',event); return false;",
+						class: "yadcf-filter-reset-button range-number-slider-reset-button " + columnObj.reset_button_style_class,
+						text: filter_reset_button_text
+					}));
 				}
 			}
 
@@ -2607,7 +2707,7 @@ if (!Object.entries) {
 				if (args.hasOwnProperty(columnObjKey)) {
 					columnObj = args[columnObjKey];
 
-					options_tmp = '';
+					options_tmp = $();
 					tmpStr = '';
 					data = columnObj.data;
 					column_data = [];
@@ -2749,16 +2849,25 @@ if (!Object.entries) {
 						if (columnObj.data_as_is !== true) {
 							if (columnObj.omit_default_label !== true) {
 								if (columnObj.filter_type === "select" || columnObj.filter_type === 'custom_func') {
-									options_tmp = "<option value=\"" + "-1" + "\">" + filter_default_label + "</option>";
+									options_tmp = $("<option>", {
+										value: "-1",
+										text: filter_default_label
+									});
 
 									if (columnObj.select_type === 'select2' && columnObj.select_type_options.placeholder !== undefined && columnObj.select_type_options.allowClear === true) {
-										options_tmp = "<option value=\"\"></option>";
+										options_tmp = $("<option>", {
+											value: ""
+										});
 									}
 								} else if (columnObj.filter_type === "multi_select" || columnObj.filter_type === 'multi_select_custom_func') {
 									if (columnObj.select_type === undefined) {
-										options_tmp = "<option data-placeholder=\"true\" value=\"" + "-1" + "\">" + filter_default_label + "</option>";
+										options_tmp = $("<option>", {
+											"data-placeholder": "true",
+											value: "-1",
+											text: filter_default_label
+										});
 									} else {
-										options_tmp = "";
+										options_tmp = $();
 									}
 								}
 							}
@@ -2766,19 +2875,31 @@ if (!Object.entries) {
 							if (columnObj.append_data_to_table_data === undefined) {
 								if (typeof column_data[0] === 'object') {
 									for (ii = 0; ii < column_data.length; ii++) {
-										options_tmp += "<option value=\"" + (column_data[ii].value + '').replace(/"/g, '&quot;') + "\">" + column_data[ii].label + "</option>";
+										options_tmp = options_tmp.add($("<option>", {
+											value: (column_data[ii].value + '').replace(/"/g, '&quot;'),
+											text: column_data[ii].label
+										}));
 									}
 								} else {
 									for (ii = 0; ii < column_data.length; ii++) {
-										options_tmp += "<option value=\"" + (column_data[ii] + '').replace(/"/g, '&quot;') + "\">" + column_data[ii] + "</option>";
+										options_tmp = options_tmp.add($("<option>", {
+											value: (column_data[ii] + '').replace(/"/g, '&quot;'),
+											text: column_data[ii]
+										}));
 									}
 								}
 							} else {
 								for (ii = 0; ii < column_data.length; ii++) {
 									if (typeof column_data[ii] === 'object') {
-										options_tmp += "<option value=\"" + (column_data[ii].value + '').replace(/"/g, '&quot;') + "\">" + column_data[ii].label + "</option>";
+										options_tmp = options_tmp.add($("<option>", {
+											value: (column_data[ii].value + '').replace(/"/g, '&quot;'),
+											text: column_data[ii].label
+										}));
 									} else {
-										options_tmp += "<option value=\"" + (column_data[ii] + '').replace(/"/g, '&quot;') + "\">" + column_data[ii] + "</option>";
+										options_tmp = options_tmp.add($("<option>", {
+											value: (column_data[ii] + '').replace(/"/g, '&quot;'),
+											text: column_data[ii]
+										}));
 									}
 								}
 							}
@@ -2832,7 +2953,9 @@ if (!Object.entries) {
 								columnObj.filter_container_selector = "#" + filter_container_id;
 							}
 							if ($("#yadcf-filter-wrapper-" + generateTableSelectorJQFriendlyNew(columnObj.filter_container_selector)).length === 0) {
-								$(columnObj.filter_container_selector).append("<div id=\"yadcf-filter-wrapper-" + generateTableSelectorJQFriendlyNew(columnObj.filter_container_selector) + "\"></div>");
+								$(columnObj.filter_container_selector).append($("<div>", {
+									id: "yadcf-filter-wrapper-" + generateTableSelectorJQFriendlyNew(columnObj.filter_container_selector)
+								}));
 							}
 							filter_selector_string = "#yadcf-filter-wrapper-" + generateTableSelectorJQFriendlyNew(columnObj.filter_container_selector);
 						}
@@ -2840,30 +2963,58 @@ if (!Object.entries) {
 						if (columnObj.filter_type === "select" || columnObj.filter_type === 'custom_func') {
 
 							//add a wrapper to hold both filter and reset button
-							$(filter_selector_string).append("<div id=\"yadcf-filter-wrapper-" + table_selector_jq_friendly + "-" + column_number + "\" class=\"yadcf-filter-wrapper\"></div>");
+							$(filter_selector_string).append($("<div>", {
+								id: "yadcf-filter-wrapper-" + table_selector_jq_friendly + "-" + column_number,
+								class: "yadcf-filter-wrapper"
+							}));
 							filter_selector_string += " div.yadcf-filter-wrapper";
 
 							if (columnObj.filter_type === "select") {
-								filterActionStr = 'onchange="yadcf.doFilter(this, \'' + table_selector_jq_friendly + '\', ' + column_number + ', \'' + filter_match_mode + '\');"';
+								filterActionStr = 'yadcf.doFilter(this, \'' + table_selector_jq_friendly + '\', ' + column_number + ', \'' + filter_match_mode + '\');';
 								if (columnObj.externally_triggered === true) {
 									filterActionStr = '';
 								}
-								$(filter_selector_string).append("<select id=\"yadcf-filter-" + table_selector_jq_friendly + "-" + column_number + "\" class=\"yadcf-filter " + columnObj.style_class + "\" " +
-									filterActionStr + " onkeydown=\"yadcf.preventDefaultForEnter(event);\" onmousedown=\"yadcf.stopPropagation(event);\" onclick='yadcf.stopPropagation(event);'>" + column_data + "</select>");
+								$(filter_selector_string).append($("<select>", {
+									id: "yadcf-filter-" + table_selector_jq_friendly + "-" + column_number,
+									class: "yadcf-filter " + columnObj.style_class,
+									onchange: filterActionStr,
+									onkeydown: "yadcf.preventDefaultForEnter(event);",
+									onmousedown: "yadcf.stopPropagation(event);",
+									onclick: "yadcf.stopPropagation(event);",
+									html: column_data
+								}));
 								if (filter_reset_button_text !== false) {
-									$(filter_selector_string).find(".yadcf-filter").after("<button type=\"button\" " +
-										"id=\"yadcf-filter-" + table_selector_jq_friendly + "-" + column_number + "-reset\" onmousedown=\"yadcf.stopPropagation(event);\" onclick=\"yadcf.stopPropagation(event);yadcf.doFilter('clear', '" + table_selector_jq_friendly + "', " + column_number + "); return false;\" class=\"yadcf-filter-reset-button " + columnObj.reset_button_style_class + "\">" + filter_reset_button_text + "</button>");
+									$(filter_selector_string).find(".yadcf-filter").after($("<button>", {
+										type: "button",
+										id: "yadcf-filter-" + table_selector_jq_friendly + "-" + column_number + "-reset",
+										onmousedown: "yadcf.stopPropagation(event);",
+										onclick: "yadcf.stopPropagation(event);yadcf.doFilter('clear', '" + table_selector_jq_friendly + "', " + column_number + "); return false;",
+										class: "yadcf-filter-reset-button " + columnObj.reset_button_style_class,
+										text: filter_reset_button_text
+									}));
 								}
 							} else {
-								filterActionStr = 'onchange="yadcf.doFilterCustomDateFunc(this, \'' + table_selector_jq_friendly  + '\', ' +  column_number + ');"';
+								filterActionStr = 'yadcf.doFilterCustomDateFunc(this, \'' + table_selector_jq_friendly  + '\', ' +  column_number + ');';
 								if (columnObj.externally_triggered === true) {
 									filterActionStr = '';
 								}
-								$(filter_selector_string).append("<select id=\"yadcf-filter-" + table_selector_jq_friendly + "-" + column_number + "\" class=\"yadcf-filter " + columnObj.style_class + "\" " +
-									filterActionStr + " onkeydown=\"yadcf.preventDefaultForEnter(event);\" onmousedown=\"yadcf.stopPropagation(event);\" onclick='yadcf.stopPropagation(event);'>" + column_data + "</select>");
+								$(filter_selector_string).append($("<select>", {
+									id: "yadcf-filter-" + table_selector_jq_friendly + "-" + column_number,
+									class: "yadcf-filter " + columnObj.style_class,
+									onchange: filterActionStr,
+									onkeydown: "yadcf.preventDefaultForEnter(event);",
+									onmousedown: "yadcf.stopPropagation(event);",
+									onclick: "yadcf.stopPropagation(event);",
+									html: column_data
+								}));
 								if (filter_reset_button_text !== false) {
-									$(filter_selector_string).find(".yadcf-filter").after("<button type=\"button\" onmousedown=\"yadcf.stopPropagation(event);\" " +
-										"onclick=\"yadcf.stopPropagation(event);yadcf.doFilterCustomDateFunc('clear', '" + table_selector_jq_friendly + "', " + column_number + "); return false;\" class=\"yadcf-filter-reset-button " + columnObj.reset_button_style_class + "\">" + filter_reset_button_text + "</button>");
+									$(filter_selector_string).find(".yadcf-filter").after($("<button>", {
+										type: "button",
+										onmousedown: "yadcf.stopPropagation(event);",
+										onclick: "yadcf.stopPropagation(event);yadcf.doFilterCustomDateFunc('clear', '" + table_selector_jq_friendly + "', " + column_number + "); return false;",
+										class: "yadcf-filter-reset-button " + columnObj.reset_button_style_class,
+										text: filter_reset_button_text
+									}));
 								}
 
 								if (settingsDt.oFeatures.bStateSave === true && settingsDt.oLoadedState) {
@@ -2896,20 +3047,37 @@ if (!Object.entries) {
 						} else if (columnObj.filter_type === "multi_select" || columnObj.filter_type === 'multi_select_custom_func') {
 
 							//add a wrapper to hold both filter and reset button
-							$(filter_selector_string).append("<div id=\"yadcf-filter-wrapper-" + table_selector_jq_friendly + "-" + column_number + "\" class=\"yadcf-filter-wrapper\"></div>");
+							$(filter_selector_string).append($("<div>", {
+								id: "yadcf-filter-wrapper-" + table_selector_jq_friendly + "-" + column_number,
+								class: "yadcf-filter-wrapper"
+							}));
 							filter_selector_string += " div.yadcf-filter-wrapper";
 
 							if (columnObj.filter_type === "multi_select") {
-								filterActionStr = 'onchange="yadcf.doFilterMultiSelect(this, \'' + table_selector_jq_friendly + '\', ' + column_number + ', \'' + filter_match_mode + '\');"';
+								filterActionStr = 'yadcf.doFilterMultiSelect(this, \'' + table_selector_jq_friendly + '\', ' + column_number + ', \'' + filter_match_mode + '\');';
 								if (columnObj.externally_triggered === true) {
 									filterActionStr = '';
 								}
-								$(filter_selector_string).append("<select multiple data-placeholder=\"" + filter_default_label + "\" id=\"yadcf-filter-" + table_selector_jq_friendly + "-" + column_number + "\" class=\"yadcf-filter " + columnObj.style_class + "\" " +
-									filterActionStr + " onkeydown=\"yadcf.preventDefaultForEnter(event);\" onmousedown=\"yadcf.stopPropagation(event);\" onclick='yadcf.stopPropagation(event);'>" + column_data + "</select>");
+								$(filter_selector_string).append($("<select>", {
+									multiple: true,
+									"data-placeholder": filter_default_label,
+									id: "yadcf-filter-" + table_selector_jq_friendly + "-" + column_number,
+									class: "yadcf-filter " + columnObj.style_class,
+									onchange: filterActionStr,
+									onkeydown: "yadcf.preventDefaultForEnter(event);",
+									onmousedown: "yadcf.stopPropagation(event);",
+									onclick: "yadcf.stopPropagation(event);",
+									html: column_data
+								}));
 
 								if (filter_reset_button_text !== false) {
-									$(filter_selector_string).find(".yadcf-filter").after("<button type=\"button\" onmousedown=\"yadcf.stopPropagation(event);\" " +
-										"onclick=\"yadcf.stopPropagation(event);yadcf.doFilter('clear', '" + table_selector_jq_friendly + "', " + column_number + "); return false;\" class=\"yadcf-filter-reset-button " + columnObj.reset_button_style_class + "\">" + filter_reset_button_text + "</button>");
+									$(filter_selector_string).find(".yadcf-filter").after($("<button>", {
+										type: "button",
+										onmousedown: "yadcf.stopPropagation(event);",
+										onclick: "yadcf.stopPropagation(event);yadcf.doFilter('clear', '" + table_selector_jq_friendly + "', " + column_number + "); return false;",
+										class: "yadcf-filter-reset-button " + columnObj.reset_button_style_class,
+										text: filter_reset_button_text
+									}));
 								}
 
 								if (settingsDt.aoPreSearchCols[column_position].sSearch !== '') {
@@ -2920,16 +3088,30 @@ if (!Object.entries) {
 									$('#yadcf-filter-' + table_selector_jq_friendly + '-' + column_number).val(tmpStr);
 								}
 							} else {
-								filterActionStr = 'onchange="yadcf.doFilterCustomDateFunc(this, \'' + table_selector_jq_friendly + '\', ' + column_number + ');"';
+								filterActionStr = 'yadcf.doFilterCustomDateFunc(this, \'' + table_selector_jq_friendly + '\', ' + column_number + ');';
 								if (columnObj.externally_triggered === true) {
 									filterActionStr = '';
 								}
-								$(filter_selector_string).append("<select multiple data-placeholder=\"" + filter_default_label + "\" id=\"yadcf-filter-" + table_selector_jq_friendly + "-" + column_number + "\" class=\"yadcf-filter " + columnObj.style_class + "\" " +
-									filterActionStr + " onkeydown=\"yadcf.preventDefaultForEnter(event);\" onmousedown=\"yadcf.stopPropagation(event);\" onclick='yadcf.stopPropagation(event);'>" + column_data + "</select>");
+								$(filter_selector_string).append($("<select>", {
+									multiple: true,
+									"data-placeholder": filter_default_label,
+									id: "yadcf-filter-" + table_selector_jq_friendly + "-" + column_number,
+									class: "yadcf-filter " + columnObj.style_class,
+									onchange: filterActionStr,
+									onkeydown: "yadcf.preventDefaultForEnter(event);",
+									onmousedown: "yadcf.stopPropagation(event);",
+									onclick: "yadcf.stopPropagation(event);",
+									html: column_data
+								}));
 
 								if (filter_reset_button_text !== false) {
-									$(filter_selector_string).find(".yadcf-filter").after("<button type=\"button\" onmousedown=\"yadcf.stopPropagation(event);\" " +
-										"onclick=\"yadcf.stopPropagation(event);yadcf.doFilterCustomDateFunc('clear', '" + table_selector_jq_friendly + "', " + column_number + "); return false;\" class=\"yadcf-filter-reset-button " + columnObj.reset_button_style_class + "\">" + filter_reset_button_text + "</button>");
+									$(filter_selector_string).find(".yadcf-filter").after($("<button>", {
+										type: "button",
+										onmousedown: "yadcf.stopPropagation(event);",
+										onclick: "yadcf.stopPropagation(event);yadcf.doFilterCustomDateFunc('clear', '" + table_selector_jq_friendly + "', " + column_number + "); return false;",
+										class: "yadcf-filter-reset-button " + columnObj.reset_button_style_class,
+										text: filter_reset_button_text
+									}));
 								}
 
 								if (settingsDt.oFeatures.bStateSave === true && settingsDt.oLoadedState) {
@@ -2963,28 +3145,47 @@ if (!Object.entries) {
 						} else if (columnObj.filter_type === "auto_complete") {
 
 							//add a wrapper to hold both filter and reset button
-							$(filter_selector_string).append("<div id=\"yadcf-filter-wrapper-" + table_selector_jq_friendly + "-" + column_number + "\" class=\"yadcf-filter-wrapper\"></div>");
+							$(filter_selector_string).append($("<div>", {
+								id: "yadcf-filter-wrapper-" + table_selector_jq_friendly + "-" + column_number,
+								class: "yadcf-filter-wrapper"
+							}));
 							filter_selector_string += " div.yadcf-filter-wrapper";
 
-							filterActionStr = 'onkeyup="yadcf.autocompleteKeyUP(\'' + table_selector_jq_friendly + '\',event);"';
+							filterActionStr = 'yadcf.autocompleteKeyUP(\'' + table_selector_jq_friendly + '\',event);';
 							if (columnObj.externally_triggered === true) {
 								filterActionStr = '';
 							}
-							$(filter_selector_string).append("<input onkeydown=\"yadcf.preventDefaultForEnter(event);\" id=\"yadcf-filter-" + table_selector_jq_friendly + "-" + column_number + "\" class=\"yadcf-filter\" onmousedown=\"yadcf.stopPropagation(event);\" onclick='yadcf.stopPropagation(event);" +
-							"' placeholder='" + filter_default_label + "'" + " filter_match_mode='" + filter_match_mode + "' " + filterActionStr + "></input>");
+							$(filter_selector_string).append($("<input>", {
+								onkeydown: "yadcf.preventDefaultForEnter(event);",
+								id: "yadcf-filter-" + table_selector_jq_friendly + "-" + column_number,
+								class: "yadcf-filter",
+								onmousedown: "yadcf.stopPropagation(event);",
+								onclick: "yadcf.stopPropagation(event);",
+								placeholder: filter_default_label,
+								filter_match_mode: filter_match_mode,
+								onkeyup: filterActionStr
+							}));
 							$(document).data("yadcf-filter-" + table_selector_jq_friendly + "-" + column_number, column_data);
 
 							if (filter_reset_button_text !== false) {
-								$(filter_selector_string).find(".yadcf-filter").after("<button type=\"button\" onmousedown=\"yadcf.stopPropagation(event);\" " +
-									"onclick=\"yadcf.stopPropagation(event);yadcf.doFilterAutocomplete('clear', '" + table_selector_jq_friendly + "', " + column_number + "); return false;\" class=\"yadcf-filter-reset-button " + columnObj.reset_button_style_class + "\">" + filter_reset_button_text + "</button>");
+								$(filter_selector_string).find(".yadcf-filter").after($("<button>", {
+									type: "button",
+									onmousedown: "yadcf.stopPropagation(event);",
+									onclick: "yadcf.stopPropagation(event);yadcf.doFilterAutocomplete('clear', '" + table_selector_jq_friendly + "', " + column_number + "); return false;",
+									class: "yadcf-filter-reset-button " + columnObj.reset_button_style_class,
+									text: filter_reset_button_text
+								}));
 							}
 						} else if (columnObj.filter_type === "text") {
 
 							//add a wrapper to hold both filter and reset button
-							$(filter_selector_string).append("<div id=\"yadcf-filter-wrapper-" + table_selector_jq_friendly + "-" + column_number + "\" class=\"yadcf-filter-wrapper\"></div>");
+							$(filter_selector_string).append($("<div>", {
+								id: "yadcf-filter-wrapper-" + table_selector_jq_friendly + "-" + column_number,
+								class: "yadcf-filter-wrapper"
+							}));
 							filter_selector_string += " div.yadcf-filter-wrapper";
 
-							filterActionStr = 'onkeyup="yadcf.textKeyUP(event,\'' + table_selector_jq_friendly + '\', ' + column_number + ');"';
+							filterActionStr = 'yadcf.textKeyUP(event,\'' + table_selector_jq_friendly + '\', ' + column_number + ');';
 							if (columnObj.externally_triggered === true) {
 								filterActionStr = '';
 							}
@@ -2992,20 +3193,55 @@ if (!Object.entries) {
 							exclude_str = '';
 							if (columnObj.exclude === true) {
 								if (columnObj.externally_triggered !== true) {
-									exclude_str = '<span class="yadcf-exclude-wrapper" onmousedown="yadcf.stopPropagation(event);" onclick="yadcf.stopPropagation(event);">' +
-										'<div class="yadcf-label small">' + columnObj.exclude_label + '</div><input type="checkbox" title="' + columnObj.exclude_label + '" onclick="yadcf.stopPropagation(event);yadcf.textKeyUP(event,\'' + table_selector_jq_friendly + '\',' + column_number + ');"></span>';
+									exclude_str = $("<span>", {
+										class: "yadcf-exclude-wrapper",
+										onmousedown: "yadcf.stopPropagation(event);",
+										onclick: "yadcf.stopPropagation(event);"
+									}).append($("<div>", {
+										class: "yadcf-label small",
+										text: columnObj.exclude_label
+									})).append($("<input>", {
+										type: "checkbox",
+										title: columnObj.exclude_label,
+										onclick: "yadcf.stopPropagation(event);yadcf.textKeyUP(event,'" + table_selector_jq_friendly + "'," + column_number + ");"
+									}));
 								} else {
-									exclude_str = '<span class="yadcf-exclude-wrapper" onmousedown="yadcf.stopPropagation(event);" onclick="yadcf.stopPropagation(event);">' +
-										'<div class="yadcf-label small">' + columnObj.exclude_label + '</div><input type="checkbox" title="' + columnObj.exclude_label + '" onclick="yadcf.stopPropagation(event);"></span>';
+									exclude_str = $("<span>", {
+										class: "yadcf-exclude-wrapper",
+										onmousedown: "yadcf.stopPropagation(event);",
+										onclick: "yadcf.stopPropagation(event);"
+									}).append($("<div>", {
+										class: "yadcf-label small",
+										text: columnObj.exclude_label
+									})).append($("<input>", {
+										type: "checkbox",
+										title: columnObj.exclude_label,
+										onclick: "yadcf.stopPropagation(event);"
+									}));
 								}
 							}
 
-							$(filter_selector_string).append(exclude_str + "<input type=\"text\" onkeydown=\"yadcf.preventDefaultForEnter(event);\" id=\"yadcf-filter-" + table_selector_jq_friendly + "-" + column_number + "\" class=\"yadcf-filter " + columnObj.style_class + "\" onmousedown=\"yadcf.stopPropagation(event);\" onclick='yadcf.stopPropagation(event);" +
-							"' placeholder='" + filter_default_label + "'" + " filter_match_mode='" + filter_match_mode + "' " + filterActionStr + "></input>");
+							$(filter_selector_string).append(exclude_str.append($("<input>", {
+								type: "text",
+								onkeydown: "yadcf.preventDefaultForEnter(event);",
+								id: "yadcf-filter-" + table_selector_jq_friendly + "-" + column_number,
+								class: "yadcf-filter " + columnObj.style_class,
+								onmousedown: "yadcf.stopPropagation(event);",
+								onclick: "yadcf.stopPropagation(event);",
+								placeholder: filter_default_label,
+								filter_match_mode: filter_match_mode,
+								onkeyup: filterActionStr
+							})));
 
 							if (filter_reset_button_text !== false) {
-								$(filter_selector_string).find(".yadcf-filter").after("<button type=\"button\" " + " id=\"yadcf-filter-" + table_selector_jq_friendly + "-" + column_number + "-reset\" onmousedown=\"yadcf.stopPropagation(event);\" " +
-									"onclick=\"yadcf.stopPropagation(event);yadcf.textKeyUP(event,'" + table_selector_jq_friendly + "', '" + column_number + "', 'clear'); return false;\" class=\"yadcf-filter-reset-button " + columnObj.reset_button_style_class + "\">" + filter_reset_button_text + "</button>");
+								$(filter_selector_string).find(".yadcf-filter").after($("<button>", {
+									type: "button",
+									id: "yadcf-filter-" + table_selector_jq_friendly + "-" + column_number + "-reset",
+									onmousedown: "yadcf.stopPropagation(event);",
+									onclick: "yadcf.stopPropagation(event);yadcf.textKeyUP(event,'" + table_selector_jq_friendly + "', '" + column_number + "', 'clear'); return false;",
+									class: "yadcf-filter-reset-button " + columnObj.reset_button_style_class,
+									text: filter_reset_button_text
+								}));
 							}
 
 							if (settingsDt.aoPreSearchCols[column_position].sSearch !== '') {
@@ -3252,7 +3488,7 @@ if (!Object.entries) {
 
 				min = document.getElementById(fromId).value;
 				max = document.getElementById(toId).value;
-					
+
 				if (columnObj.datepicker_type === 'jquery-ui') {
 					try {
 						if (min.length === (date_format.length + 2)) {
@@ -3966,7 +4202,10 @@ if (!Object.entries) {
 				columnForStateSaving;
 
 			//add a wrapper to hold both filter and reset button
-			$(filter_selector_string).append("<div id=\"yadcf-filter-wrapper-" + table_selector_jq_friendly + '-' + column_number_str + "\" class=\"yadcf-filter-wrapper\"></div>");
+			$(filter_selector_string).append($("<div>", {
+				id: "yadcf-filter-wrapper-" + table_selector_jq_friendly + '-' + column_number_str,
+				class: "yadcf-filter-wrapper"
+			}));
 			filter_selector_string += " div.yadcf-filter-wrapper";
 			if (column_number_str.indexOf('_') !== -1) {
 				columnForStateSaving = column_number_str.split('_')[0];
@@ -3976,11 +4215,24 @@ if (!Object.entries) {
 
 			switch (filterOptions.filter_type) {
 			case 'text':
-				$(filter_selector_string).append("<input type=\"text\" id=\"yadcf-filter-" + table_selector_jq_friendly + '-' + column_number_str + "\" class=\"yadcf-filter\" onmousedown=\"yadcf.stopPropagation(event);\" onclick='yadcf.stopPropagation(event);" +
-				"' placeholder='" + filterOptions.filter_default_label + "'" + " onkeyup=\"yadcf.textKeyUpMultiTables('" + tablesSelectors + "',event,'" + column_number_str + "');\"></input>");
+				$(filter_selector_string).append($("<input>", {
+					type: "text",
+					id: "yadcf-filter-" + table_selector_jq_friendly + '-' + column_number_str,
+					class: "yadcf-filter",
+					onmousedown: "yadcf.stopPropagation(event);",
+					onclick: "yadcf.stopPropagation(event);",
+					placeholder: filterOptions.filter_default_label,
+					onkeyup: "yadcf.textKeyUpMultiTables('" + tablesSelectors + "',event,'" + column_number_str + "');"
+				}));
 				if (filterOptions.filter_reset_button_text !== false) {
-					$(filter_selector_string).find(".yadcf-filter").after("<button type=\"button\" " + " id=\"yadcf-filter-" + table_selector_jq_friendly + '-' + column_number_str + "-reset\" onmousedown=\"yadcf.stopPropagation(event);\" " +
-						"onclick=\"yadcf.stopPropagation(event);yadcf.textKeyUpMultiTables('" + tablesSelectors + "', event,'" + column_number_str + "','clear'); return false;\" class=\"yadcf-filter-reset-button " + filterOptions.reset_button_style_class + "\">" + filterOptions.filter_reset_button_text + "</button>");
+					$(filter_selector_string).find(".yadcf-filter").after($("<button>", {
+						type: "button",
+						id: "yadcf-filter-" + table_selector_jq_friendly + '-' + column_number_str + "-reset",
+						onmousedown: "yadcf.stopPropagation(event);",
+						onclick: "yadcf.stopPropagation(event);yadcf.textKeyUpMultiTables('" + tablesSelectors + "', event,'" + column_number_str + "','clear'); return false;",
+						class: "yadcf-filter-reset-button " + filterOptions.reset_button_style_class,
+						text: filterOptions.filter_reset_button_text
+					}));
 				}
 				if (tablesArray[0].table !== undefined) {
 					tableTmp = $('#' + tablesArray[0].table().node().id).dataTable();
@@ -3997,12 +4249,18 @@ if (!Object.entries) {
 			case 'select':
 			case 'multi_select':
 				if (filterOptions.select_type === undefined) {
-					options_tmp = "<option data-placeholder=\"true\" value=\"" + "-1" + "\">" + filterOptions.filter_default_label + "</option>";
+					options_tmp = $("<option>", {
+						"data-placeholder": "true",
+						value: "-1",
+						text: filterOptions.filter_default_label
+					});
 				} else {
-					options_tmp = "";
+					options_tmp = $();
 				}
 				if (filterOptions.select_type === 'select2' && filterOptions.select_type_options.placeholder !== undefined && filterOptions.select_type_options.allowClear === true) {
-					options_tmp = "<option value=\"\"></option>";
+					options_tmp = $("<option>", {
+						value: "",
+					});
 				}
 				if (filterOptions.data === undefined) {
 					filterOptions.data = [];
@@ -4023,7 +4281,7 @@ if (!Object.entries) {
 							filterOptions.column_number = columnsTmpArr;
 						} else {
 							$(document).off('draw.dt', '#' + tablesArray[tableTmpArrIndex].table().node().id).on('draw.dt', '#' + tablesArray[tableTmpArrIndex].table().node().id, function (event, ui) {
-								var options_tmp = '',
+								var options_tmp = $(),
 									ii;
 								columnsTmpArr = filterOptions.column_number;
 								for (column_number_index = 0; column_number_index < columnsTmpArr.length; column_number_index++) {
@@ -4033,7 +4291,10 @@ if (!Object.entries) {
 								filterOptions.column_number = columnsTmpArr;
 								filterOptions.data = sortColumnData(filterOptions.data, filterOptions);
 								for (ii = 0; ii < filterOptions.data.length; ii++) {
-									options_tmp += "<option value=\"" + filterOptions.data[ii] + "\">" + filterOptions.data[ii] + "</option>";
+									options_tmp = options_tmp.add($("<option>", {
+										value: filterOptions.data[ii],
+										text: filterOptions.data[ii]
+									}));
 								}
 								$('#' + filterOptions.filter_container_id + ' select').empty().append(options_tmp);
 
@@ -4059,24 +4320,44 @@ if (!Object.entries) {
 
 				if (typeof filterOptions.data[0] === 'object') {
 					for (ii = 0; ii < filterOptions.data.length; ii++) {
-						options_tmp += "<option value=\"" + filterOptions.data[ii].value + "\">" + filterOptions.data[ii].label + "</option>";
+						options_tmp = options_tmp.add($("<option>", {
+							value: filterOptions.data[ii].value,
+							text: filterOptions.data[ii].label
+						}));
 					}
 				} else {
 					for (ii = 0; ii < filterOptions.data.length; ii++) {
-						options_tmp += "<option value=\"" + filterOptions.data[ii] + "\">" + filterOptions.data[ii] + "</option>";
+						options_tmp = options_tmp.add($("<option>", {
+							value: filterOptions.data[ii],
+							text: filterOptions.data[ii]
+						}));
 					}
 				}
 				if (filterOptions.filter_type === 'select') {
-					$(filter_selector_string).append("<select id=\"yadcf-filter-" + table_selector_jq_friendly + '-' + column_number_str + "\" class=\"yadcf-filter\" " +
-						"onchange=\"yadcf.doFilterMultiTables('" + tablesSelectors + "',event,'" + column_number_str + "')\" onmousedown=\"yadcf.stopPropagation(event);\" onclick='yadcf.stopPropagation(event);'>" + options_tmp + "</select>");
+					$(filter_selector_string).append($("<select>", {
+						id: "yadcf-filter-" + table_selector_jq_friendly + '-' + column_number_str,
+						class: "yadcf-filter",
+						onchange: "yadcf.doFilterMultiTables('" + tablesSelectors + "',event,'" + column_number_str + "')",
+						onmousedown: "yadcf.stopPropagation(event);",
+						onclick: "yadcf.stopPropagation(event);",
+						html: options_tmp
+					}));
 					if (settingsDt.aoPreSearchCols[columnForStateSaving].sSearch !== '') {
 						tmpStr = settingsDt.aoPreSearchCols[columnForStateSaving].sSearch;
 						tmpStr = yadcfParseMatchFilter(tmpStr, filterOptions.filter_match_mode);
 						$('#yadcf-filter-' + table_selector_jq_friendly + '-' + column_number_str).val(tmpStr).addClass("inuse");
 					}
 				} else if (filterOptions.filter_type === 'multi_select') {
-					$(filter_selector_string).append("<select multiple data-placeholder=\"" + filterOptions.filter_default_label + "\" id=\"yadcf-filter-" + table_selector_jq_friendly + '-' + column_number_str + "\" class=\"yadcf-filter\" " +
-						"onchange=\"yadcf.doFilterMultiTablesMultiSelect('" + tablesSelectors + "',event,'" + column_number_str + "')\" onmousedown=\"yadcf.stopPropagation(event);\" onclick='yadcf.stopPropagation(event);'>" + options_tmp + "</select>");
+					$(filter_selector_string).append($("<select>", {
+						multiple: true,
+						"data-placeholder": filterOptions.filter_default_label,
+						id: "yadcf-filter-" + table_selector_jq_friendly + '-' + column_number_str,
+						class: "yadcf-filter",
+						onchange: "yadcf.doFilterMultiTablesMultiSelect('" + tablesSelectors + "',event,'" + column_number_str + "')",
+						onmousedown: "yadcf.stopPropagation(event);",
+						onclick: "yadcf.stopPropagation(event);",
+						html: options_tmp
+					}));
 					if (settingsDt.aoPreSearchCols[columnForStateSaving].sSearch !== '') {
 						tmpStr = settingsDt.aoPreSearchCols[columnForStateSaving].sSearch;
 						tmpStr = yadcfParseMatchFilterMultiSelect(tmpStr, filterOptions.filter_match_mode);
@@ -4087,13 +4368,25 @@ if (!Object.entries) {
 				}
 				if (filterOptions.filter_type === 'select') {
 					if (filterOptions.filter_reset_button_text !== false) {
-						$(filter_selector_string).find(".yadcf-filter").after("<button type=\"button\" " + " id=\"yadcf-filter-" + table_selector_jq_friendly  + '-' + column_number_str + "-reset\" onmousedown=\"yadcf.stopPropagation(event);\" " +
-							"onclick=\"yadcf.stopPropagation(event);yadcf.doFilterMultiTables('" + tablesSelectors + "', event,'" + column_number_str + "','clear'); return false;\" class=\"yadcf-filter-reset-button " + filterOptions.reset_button_style_class + "\">" + filterOptions.filter_reset_button_text + "</button>");
+						$(filter_selector_string).find(".yadcf-filter").after($("<button>", {
+							type: "button",
+							id: "yadcf-filter-" + table_selector_jq_friendly + '-' + column_number_str + "-reset",
+							onmousedown: "yadcf.stopPropagation(event);",
+							onclick: "yadcf.stopPropagation(event);yadcf.doFilterMultiTables('" + tablesSelectors + "', event,'" + column_number_str + "','clear'); return false;",
+							class: "yadcf-filter-reset-button " + filterOptions.reset_button_style_class,
+							text: filterOptions.filter_reset_button_text
+						}));
 					}
 				} else if (filterOptions.filter_type === 'multi_select') {
 					if (filterOptions.filter_reset_button_text !== false) {
-						$(filter_selector_string).find(".yadcf-filter").after("<button type=\"button\" " + " id=\"yadcf-filter-" + table_selector_jq_friendly + '-' + column_number_str + "-reset\" onmousedown=\"yadcf.stopPropagation(event);\" " +
-							"onclick=\"yadcf.stopPropagation(event);yadcf.doFilterMultiTablesMultiSelect('" + tablesSelectors + "', event,'" + column_number_str + "','clear'); return false;\" class=\"yadcf-filter-reset-button " + filterOptions.reset_button_style_class + "\">" + filterOptions.filter_reset_button_text + "</button>");
+						$(filter_selector_string).find(".yadcf-filter").after($("<button>", {
+							type: "button",
+							id: "yadcf-filter-" + table_selector_jq_friendly + '-' + column_number_str + "-reset",
+							onmousedown: "yadcf.stopPropagation(event);",
+							onclick: "yadcf.stopPropagation(event);yadcf.doFilterMultiTablesMultiSelect('" + tablesSelectors + "', event,'" + column_number_str + "','clear'); return false;",
+							class: "yadcf-filter-reset-button " + filterOptions.reset_button_style_class,
+							text: filterOptions.filter_reset_button_text
+						}));
 					}
 				}
 
@@ -4185,7 +4478,7 @@ if (!Object.entries) {
 				}
 			}
 		}
-		
+
 		function stopPropagation(evt) {
 			close3rdPPluginsNeededClose(evt);
 			if (evt.stopPropagation !== undefined) {

--- a/jquery.dataTables.yadcf.js
+++ b/jquery.dataTables.yadcf.js
@@ -873,7 +873,7 @@ if (!Object.entries) {
 			var case_insensitive = yadcf.getOptions(oTable.selector)[original_column_number].case_insensitive;
 			if (exclude !== true) {
 				if (filter_match_mode === "contains") {
-					oTable.fnFilter(selected_value, column_number, false, true, true, case_insensitive);
+					oTable.fnFilter(selected_value, column_number, false, false, true, case_insensitive);
 				} else if (filter_match_mode === "exact") {
 					selected_value = escapeRegExp(selected_value);
 					oTable.fnFilter("^" + selected_value + "$", column_number, true, false, true, case_insensitive);
@@ -994,7 +994,7 @@ if (!Object.entries) {
 
 			$(document).data("#yadcf-filter-" + table_selector_jq_friendly + "-" + column_number + "_val", arg.value);
 
-			selected_value = $.trim($(arg).find('option:selected').val());
+			selected_value = $.trim($(arg).find('option:selected').text());
 
 			if (arg.value !== "-1") {
 				yadcfMatchFilter(oTable, selected_value, filter_match_mode, column_number_filter, false, column_number);


### PR DESCRIPTION
Fixes https://github.com/vedmack/yadcf/issues/629, improves overall security and robustness, and readability too.
I didn't test it thoroughly, but the bundled example works properly.

Note that while many places prone to XSS are now safe, there are still places which look dangerous. For example:
https://github.com/m417z/yadcf/blob/cd4bf396bc7cc46aa0f7456d5ab0775ad9a94525/jquery.dataTables.yadcf.js#L1559

If the string which is part of the expression is untrusted, it must be escaped.

This pull request took more time than I expected, I'd appreciate if it gets merged.
Thanks for the library.