### PR TITLE
Fix Order of lines 1193/1194 Bug#656

### DIFF
--- a/src/jquery.dataTables.yadcf.js
+++ b/src/jquery.dataTables.yadcf.js
@@ -1190,8 +1190,8 @@ if (!Object.entries) {
 					oTable.fnSettings().oApi._fnSaveState(oTable.fnSettings());
 				}
 			} else {
-				oTable.fnFilter("", column_number_filter);
 				$("#yadcf-filter-" + table_selector_jq_friendly + "-" + column_number).removeClass("inuse");
+				oTable.fnFilter("", column_number_filter);
 			}
 			resetIApiIndex();
 		}


### PR DESCRIPTION
This makes this part of the function follow the same syntax order of class manipulation before table manipulation, as well as corrects a bug if someone is using DataTable.on('search') for custom page scripting based on filtered columns.