### PR TITLE
Use dynamic event handlers on elements to prevent nonce-based CSP errors (unsafe-inline disallowed)

### DIFF
--- a/src/jquery.dataTables.yadcf.js
+++ b/src/jquery.dataTables.yadcf.js
@@ -1870,7 +1870,7 @@ if (!Object.entries) {
 				filter_wrapper_id,
 				oTable,
 				columnObj,
-				filterActionStr,
+				filterActionFn,
 				null_str,
 				exclude_str;
 
@@ -1900,9 +1900,9 @@ if (!Object.entries) {
 			}));
 			filter_selector_string += " div.yadcf-filter-wrapper-inner";
 
-			filterActionFn = function(jqTable){
+			filterActionFn = function(tableSel){
 				return function(event){
-					yadcf.rangeNumberKeyUP(jqTable, event);
+					yadcf.rangeNumberKeyUP(tableSel, event);
 				};
 			}(table_selector_jq_friendly);
 			if (columnObj.externally_triggered === true) {
@@ -1924,7 +1924,7 @@ if (!Object.entries) {
 				placeholder: filter_default_label[1],
 				id: toId,
 				class: "yadcf-filter-range-number yadcf-filter-range",
-				onkeyup: filterActionStr
+				onkeyup: filterActionFn
 			}));
 
 			if (filter_reset_button_text !== false) {
@@ -1932,10 +1932,10 @@ if (!Object.entries) {
 					type: "button",
 					id: "yadcf-filter-" + table_selector_jq_friendly + "-" + column_number + "-reset",
 					onmousedown: yadcf.stopPropagation,
-					onclick: function(colNo, jqTable){
+					onclick: function(colNo, tableSel){
 						return function(event){
 							yadcf.stopPropagation(event);
-							yadcf.rangeClear(jqTable, event, colNo);
+							yadcf.rangeClear(tableSel, event, colNo);
 							return false;
 						};
 					}(column_number, table_selector_jq_friendly),
@@ -1969,10 +1969,10 @@ if (!Object.entries) {
 					})).append(makeElement("<input>", {
 						type: "checkbox",
 						title: columnObj.exclude_label,
-						onclick: function(jqTable){
+						onclick: function(tableSel){
 							return function(event){
 								yadcf.stopPropagation(event);
-								yadcf.rangeNumberKeyUP(jqTable, event);
+								yadcf.rangeNumberKeyUP(tableSel, event);
 							};
 						}(table_selector_jq_friendly)
 					}));
@@ -2004,10 +2004,10 @@ if (!Object.entries) {
 				})).append(makeElement("<input>", {
 					type: "checkbox",
 					title: columnObj.null_label,
-					onclick: function(colNo, jqTable){
+					onclick: function(colNo, tableSel){
 						return function(event){
 							yadcf.stopPropagation(event);
-							yadcf.nullChecked(event, jqTable, colNo);
+							yadcf.nullChecked(event, tableSel, colNo);
 						};
 					}(column_number, table_selector_jq_friendly)
 				}));
@@ -2296,7 +2296,7 @@ if (!Object.entries) {
 				oTable,
 				columnObj,
 				datepickerObj = {},
-				filterActionStr,
+				filterActionFn,
 				$fromInput,
 				$toInput,
 				innerWrapperAdditionalClass = '';
@@ -2328,9 +2328,9 @@ if (!Object.entries) {
 			}));
 			filter_selector_string += " div.yadcf-filter-wrapper-inner";
 
-			filterActionFn = function(jqTable){
+			filterActionFn = function(tableSel){
 				return function(event){
-					yadcf.rangeDateKeyUP(jqTable, date_format, event);
+					yadcf.rangeDateKeyUP(tableSel, date_format, event);
 				};
 			}(table_selector_jq_friendly);
 			if (columnObj.externally_triggered === true) {
@@ -2352,7 +2352,7 @@ if (!Object.entries) {
 				placeholder: filter_default_label[1],
 				id: toId,
 				class: "yadcf-filter-range-date yadcf-filter-range yadcf-filter-range-end " + columnObj.style_class,
-				onkeyup: filterActionStr
+				onkeyup: filterActionFn
 			}));
 
 			$fromInput = $("#" + fromId);
@@ -2362,10 +2362,10 @@ if (!Object.entries) {
 				$(filter_selector_string_tmp).append(makeElement("<button>", {
 					type: "button",
 					onmousedown: yadcf.stopPropagation,
-					onclick: function(colNo, jqTable){
+					onclick: function(colNo, tableSel){
 						return function(event){
 							yadcf.stopPropagation(event);
-							yadcf.rangeClear(jqTable, event, colNo);
+							yadcf.rangeClear(tableSel, event, colNo);
 							return false;
 						};
 					}(column_number, table_selector_jq_friendly),
@@ -2451,7 +2451,7 @@ if (!Object.entries) {
 				oTable,
 				columnObj,
 				datepickerObj = {},
-				filterActionStr,
+				filterActionFn,
 				settingsDt;
 
 			filter_wrapper_id = "yadcf-filter-wrapper-" + table_selector_jq_friendly + "-" + column_number;
@@ -2473,7 +2473,7 @@ if (!Object.entries) {
 			filter_selector_string += " div.yadcf-filter-wrapper";
 			filter_selector_string_tmp = filter_selector_string;
 
-			filterActionFn = function(jqTable) {
+			filterActionFn = function(tableSel) {
 				return function(event){
 					yadcf.dateKeyUP(table_selector_jq_friendly, date_format, event);
 				};
@@ -2487,7 +2487,7 @@ if (!Object.entries) {
 				placeholder: filter_default_label,
 				id: dateId,
 				class: "yadcf-filter-date " + columnObj.style_class,
-				onkeyup: filterActionStr
+				onkeyup: filterActionFn
 			}));
 
 			if (filter_reset_button_text !== false) {
@@ -2495,10 +2495,10 @@ if (!Object.entries) {
 					type: "button",
 					id: dateId + "-reset",
 					onmousedown: yadcf.stopPropagation,
-					onclick: function(jqTable){
+					onclick: function(tableSel){
 						return function(event){
 							yadcf.stopPropagation(event);
-							yadcf.dateSelectSingle(jqTable, yadcf.eventTargetFixUp(event).target, 'clear');
+							yadcf.dateSelectSingle(tableSel, yadcf.eventTargetFixUp(event).target, 'clear');
 							return false;
 						};
 					}(table_selector_jq_friendly),
@@ -2833,10 +2833,10 @@ if (!Object.entries) {
 					$(filter_selector_string_tmp).append(makeElement("<button>", {
 						type: "button",
 						onmousedown: yadcf.stopPropagation,
-						onclick: function(jqTable){
+						onclick: function(tableSel){
 							return function(event){
 								yadcf.stopPropagation(event);
-								yadcf.rangeNumberSliderClear(jqTable, event);
+								yadcf.rangeNumberSliderClear(tableSel, event);
 								return false;
 							};
 						}(table_selector_jq_friendly),
@@ -3309,7 +3309,6 @@ if (!Object.entries) {
 				filters_position,
 				unique_th,
 				settingsDt,
-				filterActionStr,
 				filterActionFn,
 				custom_func_filter_value_holder,
 				exclude_str,
@@ -3640,9 +3639,9 @@ if (!Object.entries) {
 							filter_selector_string += " div.yadcf-filter-wrapper";
 
 							if (columnObj.filter_type === "select") {
-								filterActionFn = function(colNo, jqTable) {
+								filterActionFn = function(colNo, tableSel) {
 									return function(event) {
-										yadcf.doFilter(this, jqTable, colNo, filter_match_mode);
+										yadcf.doFilter(this, tableSel, colNo, filter_match_mode);
 									};
 								}(column_number, table_selector_jq_friendly);
 								if (columnObj.externally_triggered === true) {
@@ -3662,9 +3661,9 @@ if (!Object.entries) {
 										type: "button",
 										id: "yadcf-filter-" + table_selector_jq_friendly + "-" + column_number + "-reset",
 										onmousedown: yadcf.stopPropagation,
-										onclick: function(colNo, jqTable){
+										onclick: function(colNo, tableSel){
 											return function(event) {
-												yadcf.doFilter('clear', jqTable, colNo);
+												yadcf.doFilter('clear', tableSel, colNo);
 												return false;
 											}
 										}(column_number, table_selector_jq_friendly),
@@ -3695,10 +3694,10 @@ if (!Object.entries) {
 									})).append(makeElement("<input>", {
 										type: "checkbox",
 										title: columnObj.exclude_label,
-										onclick: function(colNo, jqTable){
+										onclick: function(colNo, tableSel){
 											return function(event){
 												yadcf.stopPropagation(event);
-												yadcf.doFilter('exclude', jqTable, colNo, filter_match_mode);
+												yadcf.doFilter('exclude', tableSel, colNo, filter_match_mode);
 											};
 										}(column_number, table_selector_jq_friendly)
 									}));
@@ -3716,9 +3715,9 @@ if (!Object.entries) {
 									sel.find('.yadcf-exclude-wrapper').hide();
 								}
 							} else {
-								filterActionFn = function(colNo, jqTable){
+								filterActionFn = function(colNo, tableSel){
 									return function(event){
-										yadcf.doFilterCustomDateFunc(this, jqTable, colNo);
+										yadcf.doFilterCustomDateFunc(this, tableSel, colNo);
 									}
 								}(column_number, table_selector_jq_friendly);
 								if (columnObj.externally_triggered === true) {
@@ -3727,7 +3726,7 @@ if (!Object.entries) {
 								$(filter_selector_string).append(makeElement("<select>", {
 									id: "yadcf-filter-" + table_selector_jq_friendly + "-" + column_number,
 									class: "yadcf-filter " + columnObj.style_class,
-									onchange: filterActionStr,
+									onchange: filterActionFn,
 									onkeydown: yadcf.preventDefaultForEnter,
 									onmousedown: yadcf.stopPropagation,
 									onclick: yadcf.stopPropagation,
@@ -3737,10 +3736,10 @@ if (!Object.entries) {
 									$(filter_selector_string).find(".yadcf-filter").after($("<button>", {
 										type: "button",
 										onmousedown: yadcf.stopPropagation,
-										onclick: function(colNo, jqTable){
+										onclick: function(colNo, tableSel){
 											return function(event){
 												yadcf.stopPropagation(event);
-												yadcf.doFilterCustomDateFunc('clear', jqTable, colNo);
+												yadcf.doFilterCustomDateFunc('clear', tableSel, colNo);
 												return false;
 											};
 										}(column_number, table_selector_jq_friendly),
@@ -3835,9 +3834,9 @@ if (!Object.entries) {
 							filter_selector_string += " div.yadcf-filter-wrapper";
 
 							if (columnObj.filter_type === "multi_select") {
-								filterActionFn = function(colNo, jqTable) {
+								filterActionFn = function(colNo, tableSel) {
 									return function(event) {
-										yadcf.doFilterMultiSelect(this, jqTable, colNo, filter_match_mode);
+										yadcf.doFilterMultiSelect(this, tableSel, colNo, filter_match_mode);
 									};
 								}(column_number, table_selector_jq_friendly);
 								if (columnObj.externally_triggered === true) {
@@ -3852,17 +3851,17 @@ if (!Object.entries) {
 									onkeydown: yadcf.preventDefaultForEnter,
 									onmousedown: yadcf.stopPropagation,
 									onclick: yadcf.stopPropagation,
-									html: column_data,
+									html: column_data
 								}));
 
 								if (filter_reset_button_text !== false) {
 									$(filter_selector_string).find(".yadcf-filter").after(makeElement("<button>", {
 										type: "button",
 										onmousedown: yadcf.stopPropagation,
-										onclick: function(colNo, jqTable){
+										onclick: function(colNo, tableSel){
 											return function(event) {
 												yadcf.stopPropagation(event);
-												yadcf.doFilter('clear', jqTable, colNo);
+												yadcf.doFilter('clear', tableSel, colNo);
 												return false;
 											}
 										}(column_number, table_selector_jq_friendly),
@@ -3879,9 +3878,9 @@ if (!Object.entries) {
 									$('#yadcf-filter-' + table_selector_jq_friendly + '-' + column_number).val(tmpStr);
 								}
 							} else {
-								filterActionStr = function(colNo, jqTable){
+								filterActionFn = function(colNo, tableSel){
 									return function(event){
-										yadcf.doFilterCustomDateFunc(this, jqTable, colNo);
+										yadcf.doFilterCustomDateFunc(this, tableSel, colNo);
 									};
 								}(column_number, table_selector_jq_friendly);
 								if (columnObj.externally_triggered === true) {
@@ -3903,10 +3902,10 @@ if (!Object.entries) {
 									$(filter_selector_string).find(".yadcf-filter").after($("<button>", {
 										type: "button",
 										onmousedown: yadcf.stopPropagation,
-										onclick: function(colNo, jqTable){
+										onclick: function(colNo, tableSel){
 											return function(event){
 												yadcf.stopPropagation(event);
-												yadcf.doFilterCustomDateFunc('clear', jqTable, colNo);
+												yadcf.doFilterCustomDateFunc('clear', tableSel, colNo);
 												return false;
 											};
 										}(column_number, table_selector_jq_friendly),
@@ -3952,9 +3951,9 @@ if (!Object.entries) {
 							}));
 							filter_selector_string += " div.yadcf-filter-wrapper";
 
-							filterActionFn = function(jqTable){
+							filterActionFn = function(tableSel){
 								return function(event){
-									yadcf.autocompleteKeyUP(jqTable, event);
+									yadcf.autocompleteKeyUP(tableSel, event);
 								};
 							}(table_selector_jq_friendly);
 							if (columnObj.externally_triggered === true) {
@@ -3976,10 +3975,10 @@ if (!Object.entries) {
 								$(filter_selector_string).find(".yadcf-filter").after($("<button>", {
 									type: "button",
 									onmousedown: yadcf.stopPropagation,
-									onclick: function(colNo, jqTable){
+									onclick: function(colNo, tableSel){
 										return function(event){
 											yadcf.stopPropagation(event);
-											yadcf.doFilterAutocomplete('clear', jqTable, colNo);
+											yadcf.doFilterAutocomplete('clear', tableSel, colNo);
 											return false;
 										};
 									}(column_number, table_selector_jq_friendly),
@@ -3997,10 +3996,10 @@ if (!Object.entries) {
 							filter_selector_string += " div.yadcf-filter-wrapper";
 
 
-							filterActionFn = function(colNo, tSel) {
+							filterActionFn = function(colNo, tableSel) {
 								/* IIFE closure to preserve column number. */
 								return function(event) {
-									yadcf.textKeyUP(event, tSel, colNo);
+									yadcf.textKeyUP(event, tableSel, colNo);
 								};
 							}(column_number, table_selector_jq_friendly);
 							if (columnObj.externally_triggered === true) {
@@ -4020,10 +4019,10 @@ if (!Object.entries) {
 									})).append(makeElement("<input>", {
 										type: "checkbox",
 										title: columnObj.exclude_label,
-										onclick: function(colNo, jqTable){
+										onclick: function(colNo, tableSel){
 											return function(event){
 												yadcf.stopPropagation(event);
-												yadcf.textKeyUP(event, jqTable, colNo);
+												yadcf.textKeyUP(event, tableSel, colNo);
 											};
 										}(column_number, table_selector_jq_friendly)
 									}));
@@ -4056,10 +4055,10 @@ if (!Object.entries) {
 									})).append(makeElement("<input>", {
 										type: "checkbox",
 										title: columnObj.regex_label,
-										onclick: function(colNo, jqTable){
+										onclick: function(colNo, tableSel){
 											return function(event){
 												yadcf.stopPropagation(event);
-												yadcf.textKeyUP(event, jqTable, colNo);
+												yadcf.textKeyUP(event, tableSel, colNo);
 											};
 										}(column_number, table_selector_jq_friendly)
 									}));
@@ -4091,10 +4090,10 @@ if (!Object.entries) {
 								})).append(makeElement("<input>", {
 									type: "checkbox",
 									title: columnObj.null_label,
-									onclick: function(colNo, jqTable){
+									onclick: function(colNo, tableSel){
 										return function(event){
 											yadcf.stopPropagation(event);
-											yadcf.nullChecked(event, jqTable, colNo);
+											yadcf.nullChecked(event, tableSel, colNo);
 										};
 									}(column_number, table_selector_jq_friendly)
 								}));
@@ -4146,11 +4145,11 @@ if (!Object.entries) {
 									type: "button",
 									id: "yadcf-filter-" + table_selector_jq_friendly + "-" + column_number + "-reset",
 									onmousedown: yadcf.stopPropagation,
-									onclick: function(colNo, jqTable){
+									onclick: function(colNo, tableSel){
 										/* IIFE closure to preserve column_number */
 										return function(event) {
 											yadcf.stopPropagation(event);
-											yadcf.textKeyUP(event, jqTable, colNo, 'clear');
+											yadcf.textKeyUP(event, tableSel, colNo, 'clear');
 											return false;
 										}
 									}(column_number, table_selector_jq_friendly),
@@ -5523,7 +5522,6 @@ if (!Object.entries) {
 								return function(event){
 									yadcf.stopPropagation(event);
 									yadcf.doFilterMultiTables(tablesSelectors, event, colNo);
-									return false;
 								}
 							}(column_number_str),
 							onmousedown: yadcf.stopPropagation,
@@ -5545,7 +5543,6 @@ if (!Object.entries) {
 								return function(event){
 									yadcf.stopPropagation(event);
 									yadcf.doFilterMultiTablesMultiSelect(tablesSelectors, event, colNo);
-									return false;
 								};
 							}(column_number_str),
 							onmousedown: yadcf.stopPropagation,

--- a/src/jquery.dataTables.yadcf.js
+++ b/src/jquery.dataTables.yadcf.js
@@ -1959,7 +1959,7 @@ if (!Object.entries) {
 			exclude_str = $();
 			if (columnObj.exclude === true) {
 				if (columnObj.externally_triggered !== true) {
-					exclude_str = $("<span>", {
+					exclude_str = makeElement("<span>", {
 						class: "yadcf-exclude-wrapper",
 						onmousedown: yadcf.stopPropagation,
 						onclick: yadcf.stopPropagation
@@ -1977,7 +1977,7 @@ if (!Object.entries) {
 						}(table_selector_jq_friendly)
 					}));
 				} else {
-					exclude_str = $("<span>", {
+					exclude_str = makeElement("<span>", {
 						class: "yadcf-exclude-wrapper",
 						onmousedown: yadcf.stopPropagation,
 						onclick: yadcf.stopPropagation
@@ -1994,7 +1994,7 @@ if (!Object.entries) {
 
 			null_str = $();
 			if (columnObj.null_check_box === true) {
-				null_str = $("<span>", {
+				null_str = makeElement("<span>", {
 					class: "yadcf-null-wrapper",
 					onmousedown: yadcf.stopPropagation,
 					onclick: yadcf.stopPropagation
@@ -3684,7 +3684,7 @@ if (!Object.entries) {
 								}
 								exclude_str = $();
 								if (columnObj.exclude === true) {
-									exclude_str = $("<span>", {
+									exclude_str = makeElement("<span>", {
 										class: "yadcf-exclude-wrapper",
 										onmousedown: yadcf.stopPropagation,
 										onclick: yadcf.stopPropagation
@@ -3733,7 +3733,7 @@ if (!Object.entries) {
 									html: column_data
 								}));
 								if (filter_reset_button_text !== false) {
-									$(filter_selector_string).find(".yadcf-filter").after($("<button>", {
+									$(filter_selector_string).find(".yadcf-filter").after(makeElement("<button>", {
 										type: "button",
 										onmousedown: yadcf.stopPropagation,
 										onclick: function(colNo, tableSel){
@@ -3899,7 +3899,7 @@ if (!Object.entries) {
 								}));
 
 								if (filter_reset_button_text !== false) {
-									$(filter_selector_string).find(".yadcf-filter").after($("<button>", {
+									$(filter_selector_string).find(".yadcf-filter").after(makeElement("<button>", {
 										type: "button",
 										onmousedown: yadcf.stopPropagation,
 										onclick: function(colNo, tableSel){
@@ -3972,7 +3972,7 @@ if (!Object.entries) {
 							$(document).data("yadcf-filter-" + table_selector_jq_friendly + "-" + column_number, column_data);
 
 							if (filter_reset_button_text !== false) {
-								$(filter_selector_string).find(".yadcf-filter").after($("<button>", {
+								$(filter_selector_string).find(".yadcf-filter").after(makeElement("<button>", {
 									type: "button",
 									onmousedown: yadcf.stopPropagation,
 									onclick: function(colNo, tableSel){
@@ -4009,7 +4009,7 @@ if (!Object.entries) {
 							exclude_str = $();
 							if (columnObj.exclude === true) {
 								if (columnObj.externally_triggered !== true) {
-									exclude_str = $("<span>", {
+									exclude_str = makeElement("<span>", {
 										class: "yadcf-exclude-wrapper",
 										onmousedown: yadcf.stopPropagation,
 										onclick: yadcf.stopPropagation
@@ -4027,7 +4027,7 @@ if (!Object.entries) {
 										}(column_number, table_selector_jq_friendly)
 									}));
 								} else {
-									exclude_str = $("<span>", {
+									exclude_str = makeElement("<span>", {
 										class: "yadcf-exclude-wrapper",
 										onmousedown: yadcf.stopPropagation,
 										onclick: yadcf.stopPropagation
@@ -4045,7 +4045,7 @@ if (!Object.entries) {
 							regex_str = $();
 							if (columnObj.regex_check_box === true) {
 								if (columnObj.externally_triggered !== true) {
-									regex_str = $("<span>", {
+									regex_str = makeElement("<span>", {
 										class: "yadcf-regex-wrapper",
 										onmousedown: yadcf.stopPropagation,
 										onclick: yadcf.stopPropagation
@@ -4063,7 +4063,7 @@ if (!Object.entries) {
 										}(column_number, table_selector_jq_friendly)
 									}));
 								} else {
-									regex_str = $("<span>", {
+									regex_str = makeElement("<span>", {
 										class: "yadcf-regex-wrapper",
 										onmousedown: yadcf.stopPropagation,
 										onclick: yadcf.stopPropagation
@@ -4080,7 +4080,7 @@ if (!Object.entries) {
 
 							null_str = $();
 							if (columnObj.null_check_box === true) {
-								null_str = $("<span>", {
+								null_str = makeElement("<span>", {
 									class: "yadcf-null-wrapper",
 									onmousedown: yadcf.stopPropagation,
 									onclick: yadcf.stopPropagation
@@ -5559,7 +5559,7 @@ if (!Object.entries) {
 					}
 					if (filterOptions.filter_type === 'select') {
 						if (filterOptions.filter_reset_button_text !== false) {
-							$(filter_selector_string).find(".yadcf-filter").after($("<button>", {
+							$(filter_selector_string).find(".yadcf-filter").after(makeElement("<button>", {
 								type: "button",
 								id: "yadcf-filter-" + table_selector_jq_friendly + '-' + column_number_str + "-reset",
 								onmousedown: yadcf.stopPropagation,
@@ -5576,7 +5576,7 @@ if (!Object.entries) {
 						}
 					} else if (filterOptions.filter_type === 'multi_select') {
 						if (filterOptions.filter_reset_button_text !== false) {
-							$(filter_selector_string).find(".yadcf-filter").after($("<button>", {
+							$(filter_selector_string).find(".yadcf-filter").after(makeElement("<button>", {
 								type: "button",
 								id: "yadcf-filter-" + table_selector_jq_friendly + '-' + column_number_str + "-reset",
 								onmousedown: yadcf.stopPropagation,

--- a/src/jquery.dataTables.yadcf.js
+++ b/src/jquery.dataTables.yadcf.js
@@ -1884,9 +1884,9 @@ if (!Object.entries) {
 			columnObj = getOptions(oTable.selector)[column_number];
 
 			//add a wrapper to hold both filter and reset button
-			$(filter_selector_string).append($("<div>", {
-				onmousedown: "yadcf.stopPropagation(event);",
-				onclick: "yadcf.stopPropagation(event);",
+			$(filter_selector_string).append(makeElement("<div>", {
+				onmousedown: yadcf.stopPropagation,
+				onclick: yadcf.stopPropagation,
 				id: filter_wrapper_id,
 				class: "yadcf-filter-wrapper " + columnObj.style_class
 			}));
@@ -1894,29 +1894,33 @@ if (!Object.entries) {
 			filter_selector_string_tmp = filter_selector_string;
 
 
-			$(filter_selector_string).append($("<div>", {
+			$(filter_selector_string).append(makeElement("<div>", {
 				id: "yadcf-filter-wrapper-inner-" + table_selector_jq_friendly + "-" + column_number,
 				class: "yadcf-filter-wrapper-inner" + " -" + table_selector_jq_friendly + "-" + column_number
 			}));
 			filter_selector_string += " div.yadcf-filter-wrapper-inner";
 
-			filterActionStr = 'yadcf.rangeNumberKeyUP(\'' + table_selector_jq_friendly + '\',event);';
+			filterActionFn = function(jqTable){
+				return function(event){
+					yadcf.rangeNumberKeyUP(jqTable, event);
+				};
+			}(table_selector_jq_friendly);
 			if (columnObj.externally_triggered === true) {
-				filterActionStr = '';
+				filterActionFn = function(){};
 			}
 
-			$(filter_selector_string).append($("<input>", {
-				onkeydown: "yadcf.preventDefaultForEnter(event);",
+			$(filter_selector_string).append(makeElement("<input>", {
+				onkeydown: yadcf.preventDefaultForEnter,
 				placeholder: filter_default_label[0],
 				id: fromId,
 				class: "yadcf-filter-range-number yadcf-filter-range",
-				onkeyup: filterActionStr
+				onkeyup: filterActionFn
 			}));
-			$(filter_selector_string).append($("<span>", {
+			$(filter_selector_string).append(makeElement("<span>", {
 				class: "yadcf-filter-range-number-seperator"
 			}));
-			$(filter_selector_string).append($("<input>", {
-				onkeydown: "yadcf.preventDefaultForEnter(event);",
+			$(filter_selector_string).append(makeElement("<input>", {
+				onkeydown: yadcf.preventDefaultForEnter,
 				placeholder: filter_default_label[1],
 				id: toId,
 				class: "yadcf-filter-range-number yadcf-filter-range",
@@ -1924,22 +1928,28 @@ if (!Object.entries) {
 			}));
 
 			if (filter_reset_button_text !== false) {
-				$(filter_selector_string_tmp).append($("<button>", {
+				$(filter_selector_string_tmp).append(makeElement("<button>", {
 					type: "button",
 					id: "yadcf-filter-" + table_selector_jq_friendly + "-" + column_number + "-reset",
-					onmousedown: "yadcf.stopPropagation(event);",
-					onclick: "yadcf.stopPropagation(event);yadcf.rangeClear('" + table_selector_jq_friendly + "',event," + column_number + "); return false;",
+					onmousedown: yadcf.stopPropagation,
+					onclick: function(colNo, jqTable){
+						return function(event){
+							yadcf.stopPropagation(event);
+							yadcf.rangeClear(jqTable, event, colNo);
+							return false;
+						};
+					}(column_number, table_selector_jq_friendly),
 					class: "yadcf-filter-reset-button " + columnObj.reset_button_style_class,
 					text: filter_reset_button_text
 				}));
 			}
 
 			if (columnObj.externally_triggered_checkboxes_text && typeof columnObj.externally_triggered_checkboxes_function === 'function') {
-				$(filter_selector_string_tmp).append($("<button>", {
+				$(filter_selector_string_tmp).append(makeElement("<button>", {
 					type: "button",
 					id: "yadcf-filter-" + table_selector_jq_friendly + "-" + column_number + "-externally_triggered_checkboxes-button",
-					onmousedown: "yadcf.stopPropagation(event);",
-					onclick: "yadcf.stopPropagation(event);",
+					onmousedown: yadcf.stopPropagation,
+					onclick: yadcf.stopPropagation,
 					class: "yadcf-filter-externally_triggered_checkboxes-button " + columnObj.externally_triggered_checkboxes_button_style_class,
 					text: columnObj.externally_triggered_checkboxes_text
 				}));
@@ -1951,28 +1961,33 @@ if (!Object.entries) {
 				if (columnObj.externally_triggered !== true) {
 					exclude_str = $("<span>", {
 						class: "yadcf-exclude-wrapper",
-						onmousedown: "yadcf.stopPropagation(event);",
-						onclick: "yadcf.stopPropagation(event);"
-					}).append($("<div>", {
+						onmousedown: yadcf.stopPropagation,
+						onclick: yadcf.stopPropagation
+					}).append(makeElement("<div>", {
 						class: "yadcf-label small",
 						text: columnObj.exclude_label
-					})).append($("<input>", {
+					})).append(makeElement("<input>", {
 						type: "checkbox",
 						title: columnObj.exclude_label,
-						onclick: "yadcf.stopPropagation(event);yadcf.rangeNumberKeyUP('" + table_selector_jq_friendly + "',event);"
+						onclick: function(jqTable){
+							return function(event){
+								yadcf.stopPropagation(event);
+								yadcf.rangeNumberKeyUP(jqTable, event);
+							};
+						}(table_selector_jq_friendly)
 					}));
 				} else {
 					exclude_str = $("<span>", {
 						class: "yadcf-exclude-wrapper",
-						onmousedown: "yadcf.stopPropagation(event);",
-						onclick: "yadcf.stopPropagation(event);"
-					}).append($("<div>", {
+						onmousedown: yadcf.stopPropagation,
+						onclick: yadcf.stopPropagation
+					}).append(makeElement("<div>", {
 						class: "yadcf-label small",
 						text: columnObj.exclude_label
-					})).append($("<input>", {
+					})).append(makeElement("<input>", {
 						type: "checkbox",
 						title: columnObj.exclude_label,
-						onclick: "yadcf.stopPropagation(event);"
+						onclick: yadcf.stopPropagation
 					}));
 				}
 			}
@@ -1981,15 +1996,20 @@ if (!Object.entries) {
 			if (columnObj.null_check_box === true) {
 				null_str = $("<span>", {
 					class: "yadcf-null-wrapper",
-					onmousedown: "yadcf.stopPropagation(event);",
-					onclick: "yadcf.stopPropagation(event);"
-				}).append($("<div>", {
+					onmousedown: yadcf.stopPropagation,
+					onclick: yadcf.stopPropagation
+				}).append(makeElement("<div>", {
 					class: "yadcf-label small",
 					text: columnObj.null_label
-				})).append($("<input>", {
+				})).append(makeElement("<input>", {
 					type: "checkbox",
 					title: columnObj.null_label,
-					onclick: "yadcf.stopPropagation(event);yadcf.nullChecked(event,'" + table_selector_jq_friendly + "'," + column_number + ");"
+					onclick: function(colNo, jqTable){
+						return function(event){
+							yadcf.stopPropagation(event);
+							yadcf.nullChecked(event, jqTable, colNo);
+						};
+					}(column_number, table_selector_jq_friendly)
 				}));
 				if (oTable.fnSettings().oFeatures.bServerSide !== true) {
 					addNullFilterCapability(table_selector_jq_friendly, column_number, false);
@@ -2293,38 +2313,42 @@ if (!Object.entries) {
 				innerWrapperAdditionalClass = 'input-daterange';
 			}
 			//add a wrapper to hold both filter and reset button
-			$(filter_selector_string).append($("<div>", {
-				onmousedown: "yadcf.stopPropagation(event);",
-				onclick: "yadcf.stopPropagation(event);",
+			$(filter_selector_string).append(makeElement("<div>", {
+				onmousedown: yadcf.stopPropagation,
+				onclick: yadcf.stopPropagation,
 				id: filter_wrapper_id,
 				class: "yadcf-filter-wrapper"
 			}));
 			filter_selector_string += " div.yadcf-filter-wrapper";
 			filter_selector_string_tmp = filter_selector_string;
 
-			$(filter_selector_string).append($("<div>", {
+			$(filter_selector_string).append(makeElement("<div>", {
 				id: "yadcf-filter-wrapper-inner-" + table_selector_jq_friendly + "-" + column_number,
 				class: "yadcf-filter-wrapper-inner " + innerWrapperAdditionalClass
 			}));
 			filter_selector_string += " div.yadcf-filter-wrapper-inner";
 
-			filterActionStr = 'yadcf.rangeDateKeyUP(\'' + table_selector_jq_friendly + '\',\'' + date_format + '\',event);';
+			filterActionFn = function(jqTable){
+				return function(event){
+					yadcf.rangeDateKeyUP(jqTable, date_format, event);
+				};
+			}(table_selector_jq_friendly);
 			if (columnObj.externally_triggered === true) {
-				filterActionStr = '';
+				filterActionFn = function(){};
 			}
 
-			$(filter_selector_string).append($("<input>", {
-				onkeydown: "yadcf.preventDefaultForEnter(event);",
+			$(filter_selector_string).append(makeElement("<input>", {
+				onkeydown: yadcf.preventDefaultForEnter,
 				placeholder: filter_default_label[0],
 				id: fromId,
 				class: "yadcf-filter-range-date yadcf-filter-range yadcf-filter-range-start " + columnObj.style_class,
-				onkeyup: filterActionStr
+				onkeyup: filterActionFn
 			}));
-			$(filter_selector_string).append($("<span>", {
+			$(filter_selector_string).append(makeElement("<span>", {
 				class: "yadcf-filter-range-date-seperator"
 			}));
-			$(filter_selector_string).append($("<input>", {
-				onkeydown: "yadcf.preventDefaultForEnter(event);",
+			$(filter_selector_string).append(makeElement("<input>", {
+				onkeydown: yadcf.preventDefaultForEnter,
 				placeholder: filter_default_label[1],
 				id: toId,
 				class: "yadcf-filter-range-date yadcf-filter-range yadcf-filter-range-end " + columnObj.style_class,
@@ -2335,10 +2359,16 @@ if (!Object.entries) {
 			$toInput = $("#" + toId);
 
 			if (filter_reset_button_text !== false) {
-				$(filter_selector_string_tmp).append($("<button>", {
+				$(filter_selector_string_tmp).append(makeElement("<button>", {
 					type: "button",
-					onmousedown: "yadcf.stopPropagation(event);",
-					onclick: "yadcf.stopPropagation(event);yadcf.rangeClear('" + table_selector_jq_friendly + "',event," + column_number + "); return false;",
+					onmousedown: yadcf.stopPropagation,
+					onclick: function(colNo, jqTable){
+						return function(event){
+							yadcf.stopPropagation(event);
+							yadcf.rangeClear(jqTable, event, colNo);
+							return false;
+						};
+					}(column_number, table_selector_jq_friendly),
 					class: "yadcf-filter-reset-button " + columnObj.reset_button_style_class,
 					text: filter_reset_button_text
 				}));
@@ -2434,22 +2464,26 @@ if (!Object.entries) {
 			columnObj = getOptions(oTable.selector)[column_number];
 
 			//add a wrapper to hold both filter and reset button
-			$(filter_selector_string).append($("<div>", {
-				onmousedown: "yadcf.stopPropagation(event);",
-				onclick: "yadcf.stopPropagation(event);",
+			$(filter_selector_string).append(makeElement("<div>", {
+				onmousedown: yadcf.stopPropagation,
+				onclick: yadcf.stopPropagation,
 				id: filter_wrapper_id,
 				class: "yadcf-filter-wrapper"
 			}));
 			filter_selector_string += " div.yadcf-filter-wrapper";
 			filter_selector_string_tmp = filter_selector_string;
 
-			filterActionStr = 'yadcf.dateKeyUP(\'' + table_selector_jq_friendly + '\',\'' + date_format + '\',event);';
+			filterActionFn = function(jqTable) {
+				return function(event){
+					yadcf.dateKeyUP(table_selector_jq_friendly, date_format, event);
+				};
+			}(table_selector_jq_friendly);
 			if (columnObj.externally_triggered === true) {
-				filterActionStr = '';
+				filterActionFn = function(){};
 			}
 
-			$(filter_selector_string).append($("<input>", {
-				onkeydown: "yadcf.preventDefaultForEnter(event);",
+			$(filter_selector_string).append(makeElement("<input>", {
+				onkeydown: yadcf.preventDefaultForEnter,
 				placeholder: filter_default_label,
 				id: dateId,
 				class: "yadcf-filter-date " + columnObj.style_class,
@@ -2457,11 +2491,17 @@ if (!Object.entries) {
 			}));
 
 			if (filter_reset_button_text !== false) {
-				$(filter_selector_string_tmp).append($("<button>", {
+				$(filter_selector_string_tmp).append(makeElement("<button>", {
 					type: "button",
 					id: dateId + "-reset",
-					onmousedown: "yadcf.stopPropagation(event);",
-					onclick: "yadcf.stopPropagation(event);yadcf.dateSelectSingle('" + table_selector_jq_friendly + "',yadcf.eventTargetFixUp(event).target, 'clear'); return false;",
+					onmousedown: yadcf.stopPropagation,
+					onclick: function(jqTable){
+						return function(event){
+							yadcf.stopPropagation(event);
+							yadcf.dateSelectSingle(jqTable, yadcf.eventTargetFixUp(event).target, 'clear');
+							return false;
+						};
+					}(table_selector_jq_friendly),
 					class: "yadcf-filter-reset-button " + columnObj.reset_button_style_class,
 					text: filter_reset_button_text
 				}));
@@ -2721,32 +2761,32 @@ if (!Object.entries) {
 			if (isFinite(min_val) && isFinite(max_val) && isFinite(min_state_val) && isFinite(max_state_val)) {
 
 				//add a wrapper to hold both filter and reset button
-				$(filter_selector_string).append($("<div>", {
-					onmousedown: "yadcf.stopPropagation(event);",
-					onclick: "yadcf.stopPropagation(event);",
+				$(filter_selector_string).append(makeElement("<div>", {
+					onmousedown: yadcf.stopPropagation,
+					onclick: yadcf.stopPropagation,
 					id: filter_wrapper_id,
 					class: "yadcf-filter-wrapper " + columnObj.style_class
 				}));
 				filter_selector_string += " div.yadcf-filter-wrapper";
 				filter_selector_string_tmp = filter_selector_string;
 
-				$(filter_selector_string).append($("<div>", {
+				$(filter_selector_string).append(makeElement("<div>", {
 					id: "yadcf-filter-wrapper-inner-" + table_selector_jq_friendly + "-" + column_number,
 					class: "yadcf-number-slider-filter-wrapper-inner" + " -" + table_selector_jq_friendly + "-" + column_number
 				}));
 				filter_selector_string += " div.yadcf-number-slider-filter-wrapper-inner";
 
-				$(filter_selector_string).append($("<div>", {
+				$(filter_selector_string).append(makeElement("<div>", {
 					id: sliderId,
 					class: "yadcf-filter-range-number-slider"
 				}));
 				filter_selector_string += " #" + sliderId;
 
-				$(filter_selector_string).append($("<span>", {
+				$(filter_selector_string).append(makeElement("<span>", {
 					class: "yadcf-filter-range-number-slider-min-tip-hidden hide",
 					text: min_val
 				}));
-				$(filter_selector_string).append($("<span>", {
+				$(filter_selector_string).append(makeElement("<span>", {
 					class: "yadcf-filter-range-number-slider-max-tip-hidden hide",
 					text: max_val
 				}));
@@ -2790,10 +2830,16 @@ if (!Object.entries) {
 				$("#" + sliderId).slider(sliderObj);
 
 				if (filter_reset_button_text !== false) {
-					$(filter_selector_string_tmp).append($("<button>", {
+					$(filter_selector_string_tmp).append(makeElement("<button>", {
 						type: "button",
-						onmousedown: "yadcf.stopPropagation(event);",
-						onclick: "yadcf.stopPropagation(event);yadcf.rangeNumberSliderClear('" + table_selector_jq_friendly + "',event); return false;",
+						onmousedown: yadcf.stopPropagation,
+						onclick: function(jqTable){
+							return function(event){
+								yadcf.stopPropagation(event);
+								yadcf.rangeNumberSliderClear(jqTable, event);
+								return false;
+							};
+						}(table_selector_jq_friendly),
 						class: "yadcf-filter-reset-button range-number-slider-reset-button " + columnObj.reset_button_style_class,
 						text: filter_reset_button_text
 					}));
@@ -3577,7 +3623,7 @@ if (!Object.entries) {
 								columnObj.filter_container_selector = "#" + filter_container_id;
 							}
 							if ($("#yadcf-filter-wrapper-" + generateTableSelectorJQFriendlyNew(columnObj.filter_container_selector)).length === 0) {
-								$(columnObj.filter_container_selector).append($("<div>", {
+								$(columnObj.filter_container_selector).append(makeElement("<div>", {
 									id: "yadcf-filter-wrapper-" + generateTableSelectorJQFriendlyNew(columnObj.filter_container_selector)
 								}));
 							}
@@ -3587,7 +3633,7 @@ if (!Object.entries) {
 						if (columnObj.filter_type === "select" || columnObj.filter_type === 'custom_func') {
 
 							//add a wrapper to hold both filter and reset button
-							$(filter_selector_string).append($("<div>", {
+							$(filter_selector_string).append(makeElement("<div>", {
 								id: "yadcf-filter-wrapper-" + table_selector_jq_friendly + "-" + column_number,
 								class: "yadcf-filter-wrapper"
 							}));
@@ -3627,11 +3673,11 @@ if (!Object.entries) {
 									}));
 								}
 								if (columnObj.externally_triggered_checkboxes_text && typeof columnObj.externally_triggered_checkboxes_function === 'function') {
-									$(filter_selector_string).append($("<button>", {
+									$(filter_selector_string).append(makeElement("<button>", {
 										type: "button",
 										id: "yadcf-filter-" + table_selector_jq_friendly + "-" + column_number + "-externally_triggered_checkboxes-button",
-										onmousedown: "yadcf.stopPropagation(event);",
-										onclick: "yadcf.stopPropagation(event);",
+										onmousedown: yadcf.stopPropagation,
+										onclick: yadcf.stopPropagation,
 										class: "yadcf-filter-externally_triggered_checkboxes-button " + columnObj.externally_triggered_checkboxes_button_style_class,
 										text: columnObj.externally_triggered_checkboxes_text
 									}));
@@ -3641,15 +3687,20 @@ if (!Object.entries) {
 								if (columnObj.exclude === true) {
 									exclude_str = $("<span>", {
 										class: "yadcf-exclude-wrapper",
-										onmousedown: "yadcf.stopPropagation(event);",
-										onclick: "yadcf.stopPropagation(event);"
-									}).append($("<div>", {
+										onmousedown: yadcf.stopPropagation,
+										onclick: yadcf.stopPropagation
+									}).append(makeElement("<div>", {
 										class: "yadcf-label small",
 										text: columnObj.exclude_label
-									})).append($("<input>", {
+									})).append(makeElement("<input>", {
 										type: "checkbox",
 										title: columnObj.exclude_label,
-										onclick: "yadcf.stopPropagation(event);yadcf.doFilter('exclude','" + table_selector_jq_friendly + "'," + column_number + ", '" + filter_match_mode + "');"
+										onclick: function(colNo, jqTable){
+											return function(event){
+												yadcf.stopPropagation(event);
+												yadcf.doFilter('exclude', jqTable, colNo, filter_match_mode);
+											};
+										}(column_number, table_selector_jq_friendly)
 									}));
 								}
 
@@ -3665,24 +3716,34 @@ if (!Object.entries) {
 									sel.find('.yadcf-exclude-wrapper').hide();
 								}
 							} else {
-								filterActionStr = 'yadcf.doFilterCustomDateFunc(this, \'' + table_selector_jq_friendly + '\', ' + column_number + ');';
+								filterActionFn = function(colNo, jqTable){
+									return function(event){
+										yadcf.doFilterCustomDateFunc(this, jqTable, colNo);
+									}
+								}(column_number, table_selector_jq_friendly);
 								if (columnObj.externally_triggered === true) {
-									filterActionStr = '';
+									filterActionFn = function(){};
 								}
-								$(filter_selector_string).append($("<select>", {
+								$(filter_selector_string).append(makeElement("<select>", {
 									id: "yadcf-filter-" + table_selector_jq_friendly + "-" + column_number,
 									class: "yadcf-filter " + columnObj.style_class,
 									onchange: filterActionStr,
-									onkeydown: "yadcf.preventDefaultForEnter(event);",
-									onmousedown: "yadcf.stopPropagation(event);",
-									onclick: "yadcf.stopPropagation(event);",
+									onkeydown: yadcf.preventDefaultForEnter,
+									onmousedown: yadcf.stopPropagation,
+									onclick: yadcf.stopPropagation,
 									html: column_data
 								}));
 								if (filter_reset_button_text !== false) {
 									$(filter_selector_string).find(".yadcf-filter").after($("<button>", {
 										type: "button",
-										onmousedown: "yadcf.stopPropagation(event);",
-										onclick: "yadcf.stopPropagation(event);yadcf.doFilterCustomDateFunc('clear', '" + table_selector_jq_friendly + "', " + column_number + "); return false;",
+										onmousedown: yadcf.stopPropagation,
+										onclick: function(colNo, jqTable){
+											return function(event){
+												yadcf.stopPropagation(event);
+												yadcf.doFilterCustomDateFunc('clear', jqTable, colNo);
+												return false;
+											};
+										}(column_number, table_selector_jq_friendly),
 										class: "yadcf-filter-reset-button " + columnObj.reset_button_style_class,
 										text: filter_reset_button_text
 									}));
@@ -3767,7 +3828,7 @@ if (!Object.entries) {
 						} else if (columnObj.filter_type === "multi_select" || columnObj.filter_type === 'multi_select_custom_func') {
 
 							//add a wrapper to hold both filter and reset button
-							$(filter_selector_string).append($("<div>", {
+							$(filter_selector_string).append(makeElement("<div>", {
 								id: "yadcf-filter-wrapper-" + table_selector_jq_friendly + "-" + column_number,
 								class: "yadcf-filter-wrapper"
 							}));
@@ -3818,27 +3879,37 @@ if (!Object.entries) {
 									$('#yadcf-filter-' + table_selector_jq_friendly + '-' + column_number).val(tmpStr);
 								}
 							} else {
-								filterActionStr = 'yadcf.doFilterCustomDateFunc(this, \'' + table_selector_jq_friendly + '\', ' + column_number + ');';
+								filterActionStr = function(colNo, jqTable){
+									return function(event){
+										yadcf.doFilterCustomDateFunc(this, jqTable, colNo);
+									};
+								}(column_number, table_selector_jq_friendly);
 								if (columnObj.externally_triggered === true) {
-									filterActionStr = '';
+									filterActionFn = function(){};
 								}
-								$(filter_selector_string).append($("<select>", {
+								$(filter_selector_string).append(makeElement("<select>", {
 									multiple: true,
 									"data-placeholder": filter_default_label,
 									id: "yadcf-filter-" + table_selector_jq_friendly + "-" + column_number,
 									class: "yadcf-filter " + columnObj.style_class,
-									onchange: filterActionStr,
-									onkeydown: "yadcf.preventDefaultForEnter(event);",
-									onmousedown: "yadcf.stopPropagation(event);",
-									onclick: "yadcf.stopPropagation(event);",
+									onchange: filterActionFn,
+									onkeydown: yadcf.preventDefaultForEnter,
+									onmousedown: yadcf.stopPropagation,
+									onclick: yadcf.stopPropagation,
 									html: column_data
 								}));
 
 								if (filter_reset_button_text !== false) {
 									$(filter_selector_string).find(".yadcf-filter").after($("<button>", {
 										type: "button",
-										onmousedown: "yadcf.stopPropagation(event);",
-										onclick: "yadcf.stopPropagation(event);yadcf.doFilterCustomDateFunc('clear', '" + table_selector_jq_friendly + "', " + column_number + "); return false;",
+										onmousedown: yadcf.stopPropagation,
+										onclick: function(colNo, jqTable){
+											return function(event){
+												yadcf.stopPropagation(event);
+												yadcf.doFilterCustomDateFunc('clear', jqTable, colNo);
+												return false;
+											};
+										}(column_number, table_selector_jq_friendly),
 										class: "yadcf-filter-reset-button " + columnObj.reset_button_style_class,
 										text: filter_reset_button_text
 									}));
@@ -3875,33 +3946,43 @@ if (!Object.entries) {
 						} else if (columnObj.filter_type === "auto_complete") {
 
 							//add a wrapper to hold both filter and reset button
-							$(filter_selector_string).append($("<div>", {
+							$(filter_selector_string).append(makeElement("<div>", {
 								id: "yadcf-filter-wrapper-" + table_selector_jq_friendly + "-" + column_number,
 								class: "yadcf-filter-wrapper"
 							}));
 							filter_selector_string += " div.yadcf-filter-wrapper";
 
-							filterActionStr = 'yadcf.autocompleteKeyUP(\'' + table_selector_jq_friendly + '\',event);';
+							filterActionFn = function(jqTable){
+								return function(event){
+									yadcf.autocompleteKeyUP(jqTable, event);
+								};
+							}(table_selector_jq_friendly);
 							if (columnObj.externally_triggered === true) {
-								filterActionStr = '';
+								filterActionFn = function(){};
 							}
-							$(filter_selector_string).append($("<input>", {
-								onkeydown: "yadcf.preventDefaultForEnter(event);",
+							$(filter_selector_string).append(makeElement("<input>", {
+								onkeydown: yadcf.preventDefaultForEnter,
 								id: "yadcf-filter-" + table_selector_jq_friendly + "-" + column_number,
 								class: "yadcf-filter",
-								onmousedown: "yadcf.stopPropagation(event);",
-								onclick: "yadcf.stopPropagation(event);",
+								onmousedown: yadcf.stopPropagation,
+								onclick: yadcf.stopPropagation,
 								placeholder: filter_default_label,
 								filter_match_mode: filter_match_mode,
-								onkeyup: filterActionStr
+								onkeyup: filterActionFn
 							}));
 							$(document).data("yadcf-filter-" + table_selector_jq_friendly + "-" + column_number, column_data);
 
 							if (filter_reset_button_text !== false) {
 								$(filter_selector_string).find(".yadcf-filter").after($("<button>", {
 									type: "button",
-									onmousedown: "yadcf.stopPropagation(event);",
-									onclick: "yadcf.stopPropagation(event);yadcf.doFilterAutocomplete('clear', '" + table_selector_jq_friendly + "', " + column_number + "); return false;",
+									onmousedown: yadcf.stopPropagation,
+									onclick: function(colNo, jqTable){
+										return function(event){
+											yadcf.stopPropagation(event);
+											yadcf.doFilterAutocomplete('clear', jqTable, colNo);
+											return false;
+										};
+									}(column_number, table_selector_jq_friendly),
 									class: "yadcf-filter-reset-button " + columnObj.reset_button_style_class,
 									text: filter_reset_button_text
 								}));
@@ -3909,7 +3990,7 @@ if (!Object.entries) {
 						} else if (columnObj.filter_type === "text") {
 
 							//add a wrapper to hold both filter and reset button
-							$(filter_selector_string).append($("<div>", {
+							$(filter_selector_string).append(makeElement("<div>", {
 								id: "yadcf-filter-wrapper-" + table_selector_jq_friendly + "-" + column_number,
 								class: "yadcf-filter-wrapper"
 							}));
@@ -3931,28 +4012,33 @@ if (!Object.entries) {
 								if (columnObj.externally_triggered !== true) {
 									exclude_str = $("<span>", {
 										class: "yadcf-exclude-wrapper",
-										onmousedown: "yadcf.stopPropagation(event);",
-										onclick: "yadcf.stopPropagation(event);"
-									}).append($("<div>", {
+										onmousedown: yadcf.stopPropagation,
+										onclick: yadcf.stopPropagation
+									}).append(makeElement("<div>", {
 										class: "yadcf-label small",
 										text: columnObj.exclude_label
-									})).append($("<input>", {
+									})).append(makeElement("<input>", {
 										type: "checkbox",
 										title: columnObj.exclude_label,
-										onclick: "yadcf.stopPropagation(event);yadcf.textKeyUP(event,'" + table_selector_jq_friendly + "'," + column_number + ");"
+										onclick: function(colNo, jqTable){
+											return function(event){
+												yadcf.stopPropagation(event);
+												yadcf.textKeyUP(event, jqTable, colNo);
+											};
+										}(column_number, table_selector_jq_friendly)
 									}));
 								} else {
 									exclude_str = $("<span>", {
 										class: "yadcf-exclude-wrapper",
-										onmousedown: "yadcf.stopPropagation(event);",
-										onclick: "yadcf.stopPropagation(event);"
-									}).append($("<div>", {
+										onmousedown: yadcf.stopPropagation,
+										onclick: yadcf.stopPropagation
+									}).append(makeElement("<div>", {
 										class: "yadcf-label small",
 										text: columnObj.exclude_label
-									})).append($("<input>", {
+									})).append(makeElement("<input>", {
 										type: "checkbox",
 										title: columnObj.exclude_label,
-										onclick: "yadcf.stopPropagation(event);"
+										onclick: yadcf.stopPropagation
 									}));
 								}
 							}
@@ -3962,28 +4048,33 @@ if (!Object.entries) {
 								if (columnObj.externally_triggered !== true) {
 									regex_str = $("<span>", {
 										class: "yadcf-regex-wrapper",
-										onmousedown: "yadcf.stopPropagation(event);",
-										onclick: "yadcf.stopPropagation(event);"
-									}).append($("<div>", {
+										onmousedown: yadcf.stopPropagation,
+										onclick: yadcf.stopPropagation
+									}).append(makeElement("<div>", {
 										class: "yadcf-label small",
 										text: columnObj.regex_label
-									})).append($("<input>", {
+									})).append(makeElement("<input>", {
 										type: "checkbox",
 										title: columnObj.regex_label,
-										onclick: "yadcf.stopPropagation(event);yadcf.textKeyUP(event,'" + table_selector_jq_friendly + "'," + column_number + ");"
+										onclick: function(colNo, jqTable){
+											return function(event){
+												yadcf.stopPropagation(event);
+												yadcf.textKeyUP(event, jqTable, colNo);
+											};
+										}(column_number, table_selector_jq_friendly)
 									}));
 								} else {
 									regex_str = $("<span>", {
 										class: "yadcf-regex-wrapper",
-										onmousedown: "yadcf.stopPropagation(event);",
-										onclick: "yadcf.stopPropagation(event);"
-									}).append($("<div>", {
+										onmousedown: yadcf.stopPropagation,
+										onclick: yadcf.stopPropagation
+									}).append(makeElement("<div>", {
 										class: "yadcf-label small",
 										text: columnObj.regex_label
-									})).append($("<input>", {
+									})).append(makeElement("<input>", {
 										type: "checkbox",
 										title: columnObj.regex_label,
-										onclick: "yadcf.stopPropagation(event);"
+										onclick: yadcf.stopPropagation
 									}));
 								}
 							}
@@ -3992,15 +4083,20 @@ if (!Object.entries) {
 							if (columnObj.null_check_box === true) {
 								null_str = $("<span>", {
 									class: "yadcf-null-wrapper",
-									onmousedown: "yadcf.stopPropagation(event);",
-									onclick: "yadcf.stopPropagation(event);"
-								}).append($("<div>", {
+									onmousedown: yadcf.stopPropagation,
+									onclick: yadcf.stopPropagation
+								}).append(makeElement("<div>", {
 									class: "yadcf-label small",
 									text: columnObj.null_label
-								})).append($("<input>", {
+								})).append(makeElement("<input>", {
 									type: "checkbox",
 									title: columnObj.null_label,
-									onclick: "yadcf.stopPropagation(event);yadcf.nullChecked(event,'" + table_selector_jq_friendly + "'," + column_number + ");"
+									onclick: function(colNo, jqTable){
+										return function(event){
+											yadcf.stopPropagation(event);
+											yadcf.nullChecked(event, jqTable, colNo);
+										};
+									}(column_number, table_selector_jq_friendly)
 								}));
 								if (oTable.fnSettings().oFeatures.bServerSide !== true) {
 									addNullFilterCapability(table_selector_jq_friendly, column_number, false);
@@ -4049,7 +4145,7 @@ if (!Object.entries) {
 								$(filter_selector_string).find(".yadcf-filter").after(makeElement("<button>", {
 									type: "button",
 									id: "yadcf-filter-" + table_selector_jq_friendly + "-" + column_number + "-reset",
-									onmousedown: yadcf.stopPropagation(event),
+									onmousedown: yadcf.stopPropagation,
 									onclick: function(colNo, jqTable){
 										/* IIFE closure to preserve column_number */
 										return function(event) {
@@ -5276,7 +5372,7 @@ if (!Object.entries) {
 				columnForStateSaving;
 
 			//add a wrapper to hold both filter and reset button
-			$(filter_selector_string).append($("<div>", {
+			$(filter_selector_string).append(makeElement("<div>", {
 				id: "yadcf-filter-wrapper-" + table_selector_jq_friendly + '-' + column_number_str,
 				class: "yadcf-filter-wrapper"
 			}));
@@ -5289,21 +5385,33 @@ if (!Object.entries) {
 
 			switch (filterOptions.filter_type) {
 				case 'text':
-					$(filter_selector_string).append($("<input>", {
+					$(filter_selector_string).append(makeElement("<input>", {
 						type: "text",
 						id: "yadcf-filter-" + table_selector_jq_friendly + '-' + column_number_str,
 						class: "yadcf-filter",
-						onmousedown: "yadcf.stopPropagation(event);",
-						onclick: "yadcf.stopPropagation(event);",
+						onmousedown: yadcf.stopPropagation,
+						onclick: yadcf.stopPropagation,
 						placeholder: filterOptions.filter_default_label,
-						onkeyup: "yadcf.textKeyUpMultiTables('" + tablesSelectors + "',event,'" + column_number_str + "');"
+						onkeyup: function(colNo){
+							return function(event){
+								yadcf.stopPropagation(event);
+								yadcf.textKeyUpMultiTables(tablesSelectors, event, colNo);
+								return false;
+							};
+						}(column_number_str),
 					}));
 					if (filterOptions.filter_reset_button_text !== false) {
 						$(filter_selector_string).find(".yadcf-filter").after($("<button>", {
 							type: "button",
 							id: "yadcf-filter-" + table_selector_jq_friendly + '-' + column_number_str + "-reset",
-							onmousedown: "yadcf.stopPropagation(event);",
-							onclick: "yadcf.stopPropagation(event);yadcf.textKeyUpMultiTables('" + tablesSelectors + "', event,'" + column_number_str + "','clear'); return false;",
+							onmousedown: yadcf.stopPropagation,
+							onclick: function(colNo){
+								return function(event){
+									yadcf.stopPropagation(event);
+									yadcf.textKeyUpMultiTables(tablesSelectors, event, colNo, 'clear');
+									return false;
+								};
+							}(column_number_str),
 							class: "yadcf-filter-reset-button " + filterOptions.reset_button_style_class,
 							text: filterOptions.filter_reset_button_text
 						}));
@@ -5408,12 +5516,18 @@ if (!Object.entries) {
 						}
 					}
 					if (filterOptions.filter_type === 'select') {
-						$(filter_selector_string).append($("<select>", {
+						$(filter_selector_string).append(makeElement("<select>", {
 							id: "yadcf-filter-" + table_selector_jq_friendly + '-' + column_number_str,
 							class: "yadcf-filter",
-							onchange: "yadcf.doFilterMultiTables('" + tablesSelectors + "',event,'" + column_number_str + "')",
-							onmousedown: "yadcf.stopPropagation(event);",
-							onclick: "yadcf.stopPropagation(event);",
+							onchange: function(colNo){
+								return function(event){
+									yadcf.stopPropagation(event);
+									yadcf.doFilterMultiTables(tablesSelectors, event, colNo);
+									return false;
+								}
+							}(column_number_str),
+							onmousedown: yadcf.stopPropagation,
+							onclick: yadcf.stopPropagation,
 							html: options_tmp
 						}));
 						if (settingsDt.aoPreSearchCols[columnForStateSaving].sSearch !== '') {
@@ -5422,14 +5536,20 @@ if (!Object.entries) {
 							$('#yadcf-filter-' + table_selector_jq_friendly + '-' + column_number_str).val(tmpStr).addClass("inuse");
 						}
 					} else if (filterOptions.filter_type === 'multi_select') {
-						$(filter_selector_string).append($("<select>", {
+						$(filter_selector_string).append(makeElement("<select>", {
 							multiple: true,
 							"data-placeholder": filterOptions.filter_default_label,
 							id: "yadcf-filter-" + table_selector_jq_friendly + '-' + column_number_str,
 							class: "yadcf-filter",
-							onchange: "yadcf.doFilterMultiTablesMultiSelect('" + tablesSelectors + "',event,'" + column_number_str + "')",
-							onmousedown: "yadcf.stopPropagation(event);",
-							onclick: "yadcf.stopPropagation(event);",
+							onchange: function(colNo){
+								return function(event){
+									yadcf.stopPropagation(event);
+									yadcf.doFilterMultiTablesMultiSelect(tablesSelectors, event, colNo);
+									return false;
+								};
+							}(column_number_str),
+							onmousedown: yadcf.stopPropagation,
+							onclick: yadcf.stopPropagation,
 							html: options_tmp
 						}));
 						if (settingsDt.aoPreSearchCols[columnForStateSaving].sSearch !== '') {
@@ -5445,8 +5565,14 @@ if (!Object.entries) {
 							$(filter_selector_string).find(".yadcf-filter").after($("<button>", {
 								type: "button",
 								id: "yadcf-filter-" + table_selector_jq_friendly + '-' + column_number_str + "-reset",
-								onmousedown: "yadcf.stopPropagation(event);",
-								onclick: "yadcf.stopPropagation(event);yadcf.doFilterMultiTables('" + tablesSelectors + "', event,'" + column_number_str + "','clear'); return false;",
+								onmousedown: yadcf.stopPropagation,
+								onclick: function(colNo){
+									return function(event){
+										yadcf.stopPropagation(event);
+										yadcf.doFilterMultiTables(tablesSelectors, event, colNo, 'clear');
+										return false;
+									}
+								}(column_number_str),
 								class: "yadcf-filter-reset-button " + filterOptions.reset_button_style_class,
 								text: filterOptions.filter_reset_button_text
 							}));
@@ -5456,8 +5582,14 @@ if (!Object.entries) {
 							$(filter_selector_string).find(".yadcf-filter").after($("<button>", {
 								type: "button",
 								id: "yadcf-filter-" + table_selector_jq_friendly + '-' + column_number_str + "-reset",
-								onmousedown: "yadcf.stopPropagation(event);",
-								onclick: "yadcf.stopPropagation(event);yadcf.doFilterMultiTablesMultiSelect('" + tablesSelectors + "', event,'" + column_number_str + "','clear'); return false;",
+								onmousedown: yadcf.stopPropagation,
+								onclick: function(colNo){
+									return function(event){
+										yadcf.stopPropagation(event);
+										yadcf.doFilterMultiTablesMultiSelect(tablesSelectors, event, colNo, 'clear');
+										return false;
+									};
+								}(column_number_str),
 								class: "yadcf-filter-reset-button " + filterOptions.reset_button_style_class,
 								text: filterOptions.filter_reset_button_text
 							}));

--- a/src/jquery.dataTables.yadcf.js
+++ b/src/jquery.dataTables.yadcf.js
@@ -5400,7 +5400,7 @@ if (!Object.entries) {
 						}(column_number_str),
 					}));
 					if (filterOptions.filter_reset_button_text !== false) {
-						$(filter_selector_string).find(".yadcf-filter").after($("<button>", {
+						$(filter_selector_string).find(".yadcf-filter").after(makeElement("<button>", {
 							type: "button",
 							id: "yadcf-filter-" + table_selector_jq_friendly + '-' + column_number_str + "-reset",
 							onmousedown: yadcf.stopPropagation,


### PR DESCRIPTION
This is a fix for issue #373 which causes significant issues for sites requiring strict CSP settings, allowing use of a `nonce` in the calling script tag, which which means the attached event handlers become trusted.

I have made a start as a proof of concept and on the fields/use cases that address our needs at DemandLogic. If @vedmack approves this approach, it could be refactored to match throughout. 

**UPDATE:** [JSFiddle](https://jsfiddle.net/dlstevepike/etLjacxd/15/)